### PR TITLE
Consecutive anchors get separating spaces stripped.

### DIFF
--- a/tests/HTML_To_MarkdownTest.php
+++ b/tests/HTML_To_MarkdownTest.php
@@ -49,6 +49,7 @@ class HTML_To_MarkdownTest extends PHPUnit_Framework_TestCase
     public function test_anchor()
     {
         $this->html_gives_markdown('<a href="http://modernnerd.net" title="Title">Modern Nerd</a>', '[Modern Nerd](http://modernnerd.net "Title")');
+        $this->html_gives_markdown('<a href="http://modernnerd.net" title="Title">Modern Nerd</a> <a href="http://modernnerd.net" title="Title">Modern Nerd</a>', '[Modern Nerd](http://modernnerd.net "Title") [Modern Nerd](http://modernnerd.net "Title")');
     }
 
     public function test_lists()


### PR DESCRIPTION
If you have markup like this:

``` html
<a href="http://modernnerd.net" title="Title">Modern Nerd</a> <a href="http://modernnerd.net" title="Title">Modern Nerd</a>
```

(note there is a space between the A tags) it gets converted to:

``` markdown
[Modern Nerd](http://modernnerd.net "Title")[Modern Nerd](http://modernnerd.net "Title")
```

which has no space between the tags.

This PR only adds a failing test, I don't have a solution as yet.
