### PR TITLE
an empty string was throwing an exception / malformed html

### DIFF
--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -61,6 +61,11 @@ class HtmlConverter
      */
     public function convert($html)
     {
+        
+        if ($html == '' && $this->environment->getConfig()->getOption('suppress_errors')) {
+            return '';
+        }
+        
         $document = $this->createDOMDocument($html);
 
         // Work on the entire DOM tree (including head and body)

--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -61,11 +61,10 @@ class HtmlConverter
      */
     public function convert($html)
     {
-        
-        if ($html == '' && $this->environment->getConfig()->getOption('suppress_errors')) {
+        if ($html === '' && $this->environment->getConfig()->getOption('suppress_errors')) {
             return '';
         }
-        
+
         $document = $this->createDOMDocument($html);
 
         // Work on the entire DOM tree (including head and body)


### PR DESCRIPTION
Well, is an empty string malformed html? I don't think so or at least when I set "suppress errors" to true in the config, I should not get an exception, or should I ? 

