### PR TITLE
Empty HTML strings should result in empty Markdown documents

### DIFF
--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -61,6 +61,10 @@ class HtmlConverter
      */
     public function convert($html)
     {
+        if (trim($html) === '') {
+            return '';
+        }
+
         $document = $this->createDOMDocument($html);
 
         // Work on the entire DOM tree (including head and body)

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -13,6 +13,12 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected_markdown, $result);
     }
 
+    public function test_empty_input()
+    {
+        $this->html_gives_markdown('', '');
+        $this->html_gives_markdown('     ', '');
+    }
+
     public function test_plain_text()
     {
         $this->html_gives_markdown('test', 'test');


### PR DESCRIPTION
Alternate solution to #40.