### PR TITLE
Change default italic character to `_` (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Added
  - Added `bin/html-to-markdown` script
 
+### Changed
+ - Changed default italic character to `_` (#58)
+
 ## [4.0.1]
 
 ### Fixed

--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -33,7 +33,7 @@ class HtmlConverter
             'suppress_errors' => true, // Set to false to show warnings when loading malformed HTML
             'strip_tags'      => false, // Set to true to strip tags that don't have markdown equivalents. N.B. Strips tags, not their content. Useful to clean MS Word HTML output.
             'bold_style'      => '**', // Set to '__' if you prefer the underlined style
-            'italic_style'    => '*', // Set to '_' if you prefer the underlined style
+            'italic_style'    => '_', // Set to '*' if you prefer the asterisk style
             'remove_nodes'    => '', // space-separated list of dom nodes that should be removed. example: 'meta style script'
         );
 

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -51,18 +51,19 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
 
     public function test_spans()
     {
-        $this->html_gives_markdown('<em>Test</em>', '*Test*');
-        $this->html_gives_markdown('<i>Test</i>', '*Test*');
+        $this->html_gives_markdown('<em>Test</em>', '_Test_');
+        $this->html_gives_markdown('<i>Test</i>', '_Test_');
         $this->html_gives_markdown('<strong>Test</strong>', '**Test**');
         $this->html_gives_markdown('<b>Test</b>', '**Test**');
-        $this->html_gives_markdown('<em>Test</em>', '_Test_', array('italic_style' => '_'));
-        $this->html_gives_markdown('<em>Italic</em> and a <strong>bold</strong>', '_Italic_ and a __bold__', array('italic_style' => '_', 'bold_style' => '__'));
+        $this->html_gives_markdown('<em>Test</em>', '*Test*', array('italic_style' => '*'));
+        $this->html_gives_markdown('<em>Italic</em> and a <strong>bold</strong>', '*Italic* and a __bold__', array('italic_style' => '*', 'bold_style' => '__'));
         $this->html_gives_markdown('<i>Test</i>', '_Test_', array('italic_style' => '_'));
         $this->html_gives_markdown('<strong>Test</strong>', '__Test__', array('bold_style' => '__'));
         $this->html_gives_markdown('<b>Test</b>', '__Test__', array('bold_style' => '__'));
         $this->html_gives_markdown('<span>Test</span>', '<span>Test</span>');
-        $this->html_gives_markdown('<b>Bold</b> <i>Italic</i>', '**Bold** *Italic*');
-        $this->html_gives_markdown('<b>Bold</b><i>Italic</i>', '**Bold***Italic*');
+        $this->html_gives_markdown('<b>Bold</b> <i>Italic</i>', '**Bold** _Italic_');
+        $this->html_gives_markdown('<b>Bold</b><i>Italic</i>', '**Bold**_Italic_');
+        $this->html_gives_markdown('<em>This is <strong>a test</strong></em>', '_This is **a test**_');
     }
 
     public function test_nesting()
@@ -134,7 +135,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
     public function test_malformed_html()
     {
         $this->html_gives_markdown('<code><p>Some sample HTML</p></code>', '`<p>Some sample HTML</p>`'); // Invalid HTML, but should still work
-        $this->html_gives_markdown('<strong><em>Strong italic</strong> Regular text', '***Strong italic*** Regular text'); // Missing closing </em>
+        $this->html_gives_markdown('<strong><em>Strong italic</strong> Regular text', '**_Strong italic_** Regular text'); // Missing closing </em>
     }
 
     public function test_html5_tags_are_preserved()


### PR DESCRIPTION
In CommonMark, both the single * and _ characters indicate emphasis. However,
the rules for parsing those characters are slightly different. This is
especially noticeable when combining empahsis and strong emphasis using the
* and ** indicators in the same run of test (as issue #58 demonstrated).

This change produces the resulting Markdown you'd expect to see in such cases.