### PR TITLE
Fixes conversion of <p>0</p> paragraphs (Issue #66)

### DIFF
--- a/src/Converter/ParagraphConverter.php
+++ b/src/Converter/ParagraphConverter.php
@@ -15,7 +15,7 @@ class ParagraphConverter implements ConverterInterface
     {
         $value = $element->getValue();
 
-        return (trim($value) || trim($value) === "0") ? rtrim($value) . "\n\n" : '';
+        return trim($value) !== '' ? rtrim($value) . "\n\n" : '';
     }
 
     /**

--- a/src/Converter/ParagraphConverter.php
+++ b/src/Converter/ParagraphConverter.php
@@ -15,7 +15,7 @@ class ParagraphConverter implements ConverterInterface
     {
         $value = $element->getValue();
 
-        return (trim($value)) ? rtrim($value) . "\n\n" : '';
+        return (trim($value) || trim($value) === "0") ? rtrim($value) . "\n\n" : '';
     }
 
     /**


### PR DESCRIPTION
When you pass the paragraphs `<p>0</p>` or `<p></p>` to the convert function
of the ParagraphConverter, the return value will be an empty string, because
the statement `$element->getValue()` is considered to be false. 
I added another check to that statement, so that in the case of an value of 0 in the paragraph,
the whole statement is considered to be true and 0 is returned. So now an input of `<p>0</p>` is converted to 0.