### PR TITLE
Fix for preceeding or trailing spaces within emphasis tags

### DIFF
--- a/src/Converter/EmphasisConverter.php
+++ b/src/Converter/EmphasisConverter.php
@@ -37,7 +37,10 @@ class EmphasisConverter implements ConverterInterface, ConfigurationAwareInterfa
             $style = $this->config->getOption('bold_style');
         }
 
-        return $style . $value . $style;
+        $prefix = ltrim($value) !== $value ? ' ' : '';
+        $suffix = rtrim($value) !== $value ? ' ' : '';
+
+        return $prefix . $style . trim($value) . $style . $suffix;
     }
 
     /**

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -64,6 +64,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown('<b>Bold</b> <i>Italic</i>', '**Bold** _Italic_');
         $this->html_gives_markdown('<b>Bold</b><i>Italic</i>', '**Bold**_Italic_');
         $this->html_gives_markdown('<em>This is <strong>a test</strong></em>', '_This is **a test**_');
+        $this->html_gives_markdown('<em>This is </em><strong>a </strong>test', '_This is_ **a** test');
     }
 
     public function test_nesting()


### PR DESCRIPTION
This is quite common in html

```This is <strong>bold </strong>text```

ie. the space being within the strong tags

Previously html-to-markdown would convert that to

```This is **bold **text```

Which is invalid. This PR moves the space outside the markdown tags, eg.

```This is **bold** text```