### PR TITLE
Enabling calling HtmlConvert as a function

### DIFF
--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -61,6 +61,20 @@ class HtmlConverter
     /**
      * Convert
      *
+     * @see HtmlConverter::convert
+     *
+     * @param string $html
+     *
+     * @return string The Markdown version of the html
+     */
+    public function __invoke($html)
+    {
+        return $this->convert($html);
+    }
+
+    /**
+     * Convert
+     *
      * Loads HTML and passes to getMarkdown()
      *
      * @param $html

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -190,4 +190,13 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('Strip', $result);
     }
+
+    public function test_invoke()
+    {
+        $markdown = new HtmlConverter();
+        $markdown->getConfig()->setOption('strip_tags', true);
+        $result = $markdown('<span>Strip</span>');
+
+        $this->assertEquals('Strip', $result);
+    }
 }


### PR DESCRIPTION
Adding HtmlConverter::__invoke as an alias to HtmlConverter::convert
to enable calling HtmlConverter object as functions