### PR TITLE
Add test for a self closing br tag as reported in #80

### DIFF
--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -35,6 +35,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown("test\nanother line", 'test another line');
         $this->html_gives_markdown("<p>test\nanother line</p>", 'test another line');
         $this->html_gives_markdown('<p>test<br>another line</p>', "test  \nanother line");
+        $this->html_gives_markdown('<p>test<br />another line</p>', "test  \nanother line");
     }
 
     public function test_headers()


### PR DESCRIPTION
Reported as issue #80, seems to be working. Perhaps fixed elsewhere and not noted, but adding a test to prove the functionality.