### PR TITLE
Add support for recursive entity decoding

### DIFF
--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -190,14 +190,30 @@ class HtmlConverter
     }
 
     /**
+     * Recursively decode html entities
+     *
+     * @param string $markdown
+     *
+     * @return string
+     */
+    protected function recursivelyDecode($markdown)
+    {
+        $new_markdown = html_entity_decode($markdown, ENT_QUOTES, 'UTF-8');
+        if ($new_markdown === $markdown) {
+            return $new_markdown;
+        } else {
+            return $this->recursivelyDecode($new_markdown);
+        }
+    }
+
+    /**
      * @param string $markdown
      *
      * @return string
      */
     protected function sanitize($markdown)
     {
-        $markdown = html_entity_decode($markdown, ENT_QUOTES, 'UTF-8');
-        $markdown = html_entity_decode($markdown, ENT_QUOTES, 'UTF-8'); // Double decode to cover cases like &amp;nbsp; http://www.php.net/manual/en/function.htmlentities.php#99984
+        $markdown = $this->recursivelyDecode($markdown);
         $markdown = preg_replace('/<!DOCTYPE [^>]+>/', '', $markdown); // Strip doctype declaration
         $unwanted = array('<html>', '</html>', '<body>', '</body>', '<head>', '</head>', '<?xml encoding="UTF-8">', '&#xD;');
         $markdown = str_replace($unwanted, '', $markdown); // Strip unwanted tags

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -22,6 +22,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
     public function test_plain_text()
     {
         $this->html_gives_markdown('test', 'test');
+        $this->html_gives_markdown('test1&test2&amp;test3&amp;amp;test4&amp;amp;amp;test5', 'test1&test2&test3&test4&test5');
         $this->html_gives_markdown('<p>test</p>', 'test');
 
         //expected result is in the comment for better readability


### PR DESCRIPTION
Provide support for unlimited quantity of overencoding - #88 

Should be noted that in the not uncommon case of no encoding, this will actually be more efficient, bottoming out the recursion after 1 run vs 2.