### PR TITLE
Entity decoding

### DIFF
--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -190,6 +190,23 @@ class HtmlConverter
     }
 
     /**
+     * Recursively decode html entities
+     *
+     * @param string $markdown
+     *
+     * @return string
+     */
+    public function recursivelyDecode($markdown)
+    {
+        $new_markdown = html_entity_decode($markdown, ENT_QUOTES, 'UTF-8');
+        if ($new_markdown === $markdown) {
+            return $new_markdown;
+        } else {
+            return $this->recursivelyDecode($new_markdown);
+        }
+    }
+
+    /**
      * @param string $markdown
      *
      * @return string
@@ -197,7 +214,6 @@ class HtmlConverter
     protected function sanitize($markdown)
     {
         $markdown = html_entity_decode($markdown, ENT_QUOTES, 'UTF-8');
-        $markdown = html_entity_decode($markdown, ENT_QUOTES, 'UTF-8'); // Double decode to cover cases like &amp;nbsp; http://www.php.net/manual/en/function.htmlentities.php#99984
         $markdown = preg_replace('/<!DOCTYPE [^>]+>/', '', $markdown); // Strip doctype declaration
         $unwanted = array('<html>', '</html>', '<body>', '</body>', '<head>', '</head>', '<?xml encoding="UTF-8">', '&#xD;');
         $markdown = str_replace($unwanted, '', $markdown); // Strip unwanted tags

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -22,6 +22,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
     public function test_plain_text()
     {
         $this->html_gives_markdown('test', 'test');
+        $this->html_gives_markdown('test1&test2&amp;test3&amp;amp;test4&amp;amp;amp;test5', 'test1&test2&test3&amp;test4&amp;amp;test5');
         $this->html_gives_markdown('<p>test</p>', 'test');
 
         //expected result is in the comment for better readability


### PR DESCRIPTION
Supports #60 and commonmark compat.
In the case of overencoded sources, we expose a helpful recursive unencoder. Possibly more than this module should do, but relocates current functionality. Otherwise we could add to the readme to ensure properly unencoding prior to running this.