### PR TITLE
Fix edge case for tags containing only whitespace.

### DIFF
--- a/src/Converter/EmphasisConverter.php
+++ b/src/Converter/EmphasisConverter.php
@@ -30,6 +30,10 @@ class EmphasisConverter implements ConverterInterface, ConfigurationAwareInterfa
     {
         $tag = $element->getTagName();
         $value = $element->getValue();
+        
+        if (!trim($value)) {
+            return '';
+        }
 
         if ($tag === 'i' || $tag === 'em') {
             $style = $this->config->getOption('italic_style');
@@ -40,6 +44,7 @@ class EmphasisConverter implements ConverterInterface, ConfigurationAwareInterfa
         $prefix = ltrim($value) !== $value ? ' ' : '';
         $suffix = rtrim($value) !== $value ? ' ' : '';
 
+        
         return $prefix . $style . trim($value) . $style . $suffix;
     }
 

--- a/src/Converter/EmphasisConverter.php
+++ b/src/Converter/EmphasisConverter.php
@@ -30,7 +30,7 @@ class EmphasisConverter implements ConverterInterface, ConfigurationAwareInterfa
     {
         $tag = $element->getTagName();
         $value = $element->getValue();
-        
+
         if (!trim($value)) {
             return '';
         }
@@ -44,7 +44,6 @@ class EmphasisConverter implements ConverterInterface, ConfigurationAwareInterfa
         $prefix = ltrim($value) !== $value ? ' ' : '';
         $suffix = rtrim($value) !== $value ? ' ' : '';
 
-        
         return $prefix . $style . trim($value) . $style . $suffix;
     }
 


### PR DESCRIPTION
A tag just containing spaces (or non-breaking spaces) would end up as ** or **** which would produce incorrect rendering.

The following is nonsensical, but often produced by WYSIWYG HTML editors:
`<b>&nbsp;</b>`

This fix prevents this being produced:
`****`

Or a runaway ** bold tag.