### PR TITLE
Escape blockquote-like paragraphs (#77)

### DIFF
--- a/src/Converter/ParagraphConverter.php
+++ b/src/Converter/ParagraphConverter.php
@@ -15,7 +15,27 @@ class ParagraphConverter implements ConverterInterface
     {
         $value = $element->getValue();
 
-        return trim($value) !== '' ? rtrim($value) . "\n\n" : '';
+        $markdown = '';
+
+        /*
+         * &gt; ocurrences must be escaped, otherwise instead of rendering p tags as paragraph blocks,
+         * the > will make them appear as a blockquote.
+         * To achieve this, the content of the paragraph must be exploded and then each line must be check
+         * if the first character (sans blank space) is a >
+         */
+
+        $lines = explode("\n", $value);
+        foreach ($lines as $line) {
+            if (strpos(ltrim($line), '>') === 0) {
+                // Found a > char, escaping it
+                $markdown .= '\\' . ltrim($line);
+            } else {
+                $markdown .= $line;
+            }
+            $markdown .= "\n";
+        }
+
+        return trim($markdown) !== '' ? rtrim($markdown) . "\n\n" : '';
     }
 
     /**

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -212,5 +212,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<pre><code>&lt;script type = "text/javascript"&gt; function startTimer() { var tim = window.setTimeout("hideMessage()", 5000) } &lt;/head&gt; &lt;body&gt;</code></pre>';
         $markdown = '    <script type = "text/javascript"> function startTimer() { var tim = window.setTimeout("hideMessage()", 5000) } </head> <body>';
         $this->html_gives_markdown($html, $markdown);
+        $this->html_gives_markdown('<p>&gt; &gt; Look at me! &lt; &lt;</p>', '\> > Look at me! < <');
+        $this->html_gives_markdown('<p>&gt; &gt; <b>Look</b> at me! &lt; &lt;<br />&gt; Just look at me!</p>', "\\> > **Look** at me! < <  \n\\> Just look at me!");
     }
 }


### PR DESCRIPTION
Hi!

This solves issue #77. Blockquote-like paragraphs are escaped with a \. I also added the corresponding tests.



Input:

`<p>&gt; &gt; Look at me! &lt; &lt;</p>`

Actual:

`\> > Look at me! < <`

Expected:

`\> > Look at me! < <`