### PR TITLE
Sanitization function for ParagraphConverter

### DIFF
--- a/src/Converter/ParagraphConverter.php
+++ b/src/Converter/ParagraphConverter.php
@@ -17,21 +17,13 @@ class ParagraphConverter implements ConverterInterface
 
         $markdown = '';
 
-        /*
-         * '--' ocurrences must be escaped, otherwise instead of rendering p tags as paragraph blocks,
-         * the -- will make them appear as a header.
-         * To achieve this, the content of the paragraph must be exploded and then each line must be check
-         * if the first character (sans blank space) is a --
-         */
-
         $lines = preg_split('/\r\n|\r|\n/', $value);
         foreach ($lines as $line) {
-            if (strpos(ltrim($line), '--') === 0) {
-                // Found a -- structure, escaping it
-                $markdown .= '\\' . ltrim($line);
-            } else {
-                $markdown .= $line;
-            }
+            /*
+             * Some special characters need to be escaped based on the position that they appear
+             * The following function will deal with those special cases.
+             */
+            $markdown .= $this->escapeSpecialCharacters($line);
             $markdown .= "\n";
         }
 
@@ -44,5 +36,48 @@ class ParagraphConverter implements ConverterInterface
     public function getSupportedTags()
     {
         return array('p');
+    }
+
+    /**
+     * @param string $line
+     *
+     * @return string
+     */
+    private function escapeSpecialCharacters($line)
+    {
+        $line = $this->escapeHeaderlikeCharacters($line);
+        $line = $this->escapeBlockquotelikeCharacters($line);
+
+        return $line;
+    }
+
+    /**
+     * @param string $line
+     *
+     * @return string
+     */
+    private function escapeBlockquotelikeCharacters($line)
+    {
+        if (strpos(ltrim($line), '>') === 0) {
+            // Found a > char, escaping it
+            return '\\' . ltrim($line);
+        } else {
+            return $line;
+        }
+    }
+
+    /**
+     * @param string $line
+     *
+     * @return string
+     */
+    private function escapeHeaderlikeCharacters($line)
+    {
+        if (strpos(ltrim($line), '--') === 0) {
+            // Found a -- structure, escaping it
+            return '\\' . ltrim($line);
+        } else {
+            return $line;
+        }
     }
 }

--- a/src/Converter/ParagraphConverter.php
+++ b/src/Converter/ParagraphConverter.php
@@ -18,16 +18,16 @@ class ParagraphConverter implements ConverterInterface
         $markdown = '';
 
         /*
-         * &gt; ocurrences must be escaped, otherwise instead of rendering p tags as paragraph blocks,
-         * the > will make them appear as a blockquote.
+         * '--' ocurrences must be escaped, otherwise instead of rendering p tags as paragraph blocks,
+         * the -- will make them appear as a header.
          * To achieve this, the content of the paragraph must be exploded and then each line must be check
-         * if the first character (sans blank space) is a >
+         * if the first character (sans blank space) is a --
          */
 
-        $lines = explode("\n", $value);
+        $lines = preg_split('/\r\n|\r|\n/', $value);
         foreach ($lines as $line) {
-            if (strpos(ltrim($line), '>') === 0) {
-                // Found a > char, escaping it
+            if (strpos(ltrim($line), '--') === 0) {
+                // Found a -- structure, escaping it
                 $markdown .= '\\' . ltrim($line);
             } else {
                 $markdown .= $line;

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -218,5 +218,6 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown($html, $markdown);
         $this->html_gives_markdown('<p>&gt; &gt; Look at me! &lt; &lt;</p>', '\> > Look at me! < <');
         $this->html_gives_markdown('<p>&gt; &gt; <b>Look</b> at me! &lt; &lt;<br />&gt; Just look at me!</p>', "\\> > **Look** at me! < <  \n\\> Just look at me!");
+        $this->html_gives_markdown('<p>Foo<br>--<br>Bar<br>Foo--</p>', "Foo  \n\\--  \nBar  \nFoo--");
     }
 }


### PR DESCRIPTION
This fixes issue #76 and sets the path for future sanitization tasks.

On the ParagraphConverter I added a new function that will handle all the sanitization needed. Right now it has two different sanitizators, one for headerlike characters and one for blockquotelike characters.

Since it scans the paragraph contents line by line, new sanitizators can be added in the future.

I also added new tests.

Please check it out and tell me what you think.