### PR TITLE
Escaping ordered list-like lines

### DIFF
--- a/src/Converter/ParagraphConverter.php
+++ b/src/Converter/ParagraphConverter.php
@@ -47,6 +47,7 @@ class ParagraphConverter implements ConverterInterface
     {
         $line = $this->escapeHeaderlikeCharacters($line);
         $line = $this->escapeBlockquotelikeCharacters($line);
+        $line = $this->escapeOrderedListlikeCharacters($line);
 
         return $line;
     }
@@ -76,6 +77,22 @@ class ParagraphConverter implements ConverterInterface
         if (strpos(ltrim($line), '--') === 0) {
             // Found a -- structure, escaping it
             return '\\' . ltrim($line);
+        } else {
+            return $line;
+        }
+    }
+
+    /**
+     * @param string $line
+     *
+     * @return string
+     */
+    private function escapeOrderedListlikeCharacters($line)
+    {
+        // This regex will match numbers ending on ')' or '.' that are at the beginning of the line.
+        if (preg_match('/^[0-9]+(?=\)|\.)/', $line, $match)) {
+            // Found an Ordered list like character, escaping it
+            return substr_replace($line, '\\', strlen($match[0]), 0);
         } else {
             return $line;
         }

--- a/src/Element.php
+++ b/src/Element.php
@@ -84,8 +84,7 @@ class Element implements ElementInterface
      */
     public function getParent()
     {
-        $node = $this->node->parentNode;
-        return ($node) ? new static($node) : null;
+        return new static($this->node->parentNode) ?: null;
     }
 
     /**

--- a/src/Element.php
+++ b/src/Element.php
@@ -84,7 +84,8 @@ class Element implements ElementInterface
      */
     public function getParent()
     {
-        return new static($this->node->parentNode) ?: null;
+        $node = $this->node->parentNode;
+        return ($node) ? new static($node) : null;
     }
 
     /**

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -219,5 +219,6 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown('<p>&gt; &gt; Look at me! &lt; &lt;</p>', '\> > Look at me! < <');
         $this->html_gives_markdown('<p>&gt; &gt; <b>Look</b> at me! &lt; &lt;<br />&gt; Just look at me!</p>', "\\> > **Look** at me! < <  \n\\> Just look at me!");
         $this->html_gives_markdown('<p>Foo<br>--<br>Bar<br>Foo--</p>', "Foo  \n\\--  \nBar  \nFoo--");
+        $this->html_gives_markdown("<p>123456789) Foo and 1234567890) Bar!</p>\n<p>1. Platz in 'Das große Backen'</p>", "123456789\\) Foo and 1234567890) Bar!\n\n1\\. Platz in 'Das große Backen'");
     }
 }


### PR DESCRIPTION
Hi!

This fixes issue #73. It will match ordered list like characters via regex and will add a \ to escape them.