### PR TITLE
Simple refactor for the sanitization function

### DIFF
--- a/src/Converter/ParagraphConverter.php
+++ b/src/Converter/ParagraphConverter.php
@@ -49,6 +49,7 @@ class ParagraphConverter implements ConverterInterface
         $line = $this->escapeBlockquotelikeCharacters($line);
         $line = $this->escapeOrderedListlikeCharacters($line);
         $line = $this->escapeListlikeCharacters($line);
+        $line = $this->escapeTaglikeCharacters($line);
 
         return $line;
     }
@@ -109,6 +110,21 @@ class ParagraphConverter implements ConverterInterface
         if (strpos(ltrim($line), '- ') === 0 || strpos(ltrim($line), '+ ') === 0) {
             // Found an list like character, escaping it
             return '\\' . ltrim($line);
+        } else {
+            return $line;
+        }
+    }
+
+    /**
+     * @param string $line
+     *
+     * @return string
+     */
+    private function escapeTaglikeCharacters($line)
+    {
+        if (strpos($line, '<!--') !== false) {
+            // Found an tag like character, escaping it
+            return substr_replace($line, '\\', strpos($line, '<!--'), 0);
         } else {
             return $line;
         }

--- a/src/Converter/ParagraphConverter.php
+++ b/src/Converter/ParagraphConverter.php
@@ -45,11 +45,9 @@ class ParagraphConverter implements ConverterInterface
      */
     private function escapeSpecialCharacters($line)
     {
-        $line = $this->escapeHeaderlikeCharacters($line);
-        $line = $this->escapeBlockquotelikeCharacters($line);
-        $line = $this->escapeOrderedListlikeCharacters($line);
-        $line = $this->escapeListlikeCharacters($line);
-        $line = $this->escapeTaglikeCharacters($line);
+        $line = $this->escapeFirstCharacters($line);
+        $line = $this->escapeOtherCharacters($line);
+        $line = $this->escapeOtherCharactersRegex($line);
 
         return $line;
     }
@@ -59,14 +57,26 @@ class ParagraphConverter implements ConverterInterface
      *
      * @return string
      */
-    private function escapeBlockquotelikeCharacters($line)
+    private function escapeFirstCharacters($line)
     {
-        if (strpos(ltrim($line), '>') === 0) {
-            // Found a > char, escaping it
-            return '\\' . ltrim($line);
-        } else {
-            return $line;
+        $escapable = [
+            '>',
+            '- ',
+            '+ ',
+            '--',
+            '~~~',
+            '---',
+            '- - -'
+        ];
+
+        foreach ($escapable as $i) {
+            if (strpos(ltrim($line), $i) === 0) {
+                // Found a character that must be escaped, adding a backslash before
+                return '\\' . ltrim($line);
+            }
         }
+
+        return $line;
     }
 
     /**
@@ -74,14 +84,20 @@ class ParagraphConverter implements ConverterInterface
      *
      * @return string
      */
-    private function escapeHeaderlikeCharacters($line)
+    private function escapeOtherCharacters($line)
     {
-        if (strpos(ltrim($line), '--') === 0) {
-            // Found a -- structure, escaping it
-            return '\\' . ltrim($line);
-        } else {
-            return $line;
+        $escapable = [
+            '<!--'
+        ];
+
+        foreach ($escapable as $i) {
+            if (strpos($line, $i) !== false) {
+                // Found an escapable character, escaping it
+                $line = substr_replace($line, '\\', strpos($line, $i), 0);
+            }
         }
+
+        return $line;
     }
 
     /**
@@ -89,44 +105,20 @@ class ParagraphConverter implements ConverterInterface
      *
      * @return string
      */
-    private function escapeOrderedListlikeCharacters($line)
+    private function escapeOtherCharactersRegex($line)
     {
-        // This regex will match numbers ending on ')' or '.' that are at the beginning of the line.
-        if (preg_match('/^[0-9]+(?=\)|\.)/', $line, $match)) {
-            // Found an Ordered list like character, escaping it
-            return substr_replace($line, '\\', strlen($match[0]), 0);
-        } else {
-            return $line;
-        }
-    }
+        $regExs = [
+            // Match numbers ending on ')' or '.' that are at the beginning of the line.
+            '/^[0-9]+(?=\)|\.)/'
+        ];
 
-    /**
-     * @param string $line
-     *
-     * @return string
-     */
-    private function escapeListlikeCharacters($line)
-    {
-        if (strpos(ltrim($line), '- ') === 0 || strpos(ltrim($line), '+ ') === 0) {
-            // Found an list like character, escaping it
-            return '\\' . ltrim($line);
-        } else {
-            return $line;
+        foreach ($regExs as $i) {
+            if (preg_match($i, $line, $match)) {
+                // Matched an escapable character, adding a backslash on the string before the offending character
+                $line = substr_replace($line, '\\', strlen($match[0]), 0);
+            }
         }
-    }
 
-    /**
-     * @param string $line
-     *
-     * @return string
-     */
-    private function escapeTaglikeCharacters($line)
-    {
-        if (strpos($line, '<!--') !== false) {
-            // Found an tag like character, escaping it
-            return substr_replace($line, '\\', strpos($line, '<!--'), 0);
-        } else {
-            return $line;
-        }
+        return $line;
     }
 }

--- a/src/Converter/ParagraphConverter.php
+++ b/src/Converter/ParagraphConverter.php
@@ -59,7 +59,7 @@ class ParagraphConverter implements ConverterInterface
      */
     private function escapeFirstCharacters($line)
     {
-        $escapable = [
+        $escapable = array(
             '>',
             '- ',
             '+ ',
@@ -67,7 +67,7 @@ class ParagraphConverter implements ConverterInterface
             '~~~',
             '---',
             '- - -'
-        ];
+        );
 
         foreach ($escapable as $i) {
             if (strpos(ltrim($line), $i) === 0) {
@@ -86,9 +86,9 @@ class ParagraphConverter implements ConverterInterface
      */
     private function escapeOtherCharacters($line)
     {
-        $escapable = [
+        $escapable = array(
             '<!--'
-        ];
+        );
 
         foreach ($escapable as $i) {
             if (strpos($line, $i) !== false) {
@@ -107,10 +107,10 @@ class ParagraphConverter implements ConverterInterface
      */
     private function escapeOtherCharactersRegex($line)
     {
-        $regExs = [
+        $regExs = array(
             // Match numbers ending on ')' or '.' that are at the beginning of the line.
             '/^[0-9]+(?=\)|\.)/'
-        ];
+        );
 
         foreach ($regExs as $i) {
             if (preg_match($i, $line, $match)) {

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -221,5 +221,6 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown('<p>Foo<br>--<br>Bar<br>Foo--</p>', "Foo  \n\\--  \nBar  \nFoo--");
         $this->html_gives_markdown("<p>123456789) Foo and 1234567890) Bar!</p>\n<p>1. Platz in 'Das große Backen'</p>", "123456789\\) Foo and 1234567890) Bar!\n\n1\\. Platz in 'Das große Backen'");
         $this->html_gives_markdown("<p>\n+ Siri works well for TV and movies<br>\n- No 4K support\n</p>", "\+ Siri works well for TV and movies  \n\- No 4K support");
+        $this->html_gives_markdown('<p>You forgot the &lt;!--more--&gt; tag!</p>', 'You forgot the \<!--more--> tag!');
     }
 }


### PR DESCRIPTION
Hi!,

I just rewrote the sanitization function to be able to parse different characters on a single call instead of having to add a new function with each new character to sanitize.

Right now it has three functions:

- escapeFirstCharacters: Will escape problematic characters that appear at the beginning of the line, like `>` or `~~~`
- escapeOtherCharacters: Will escape other type of characters that can appear anywhere on the string, like `<!-- comment -->`
- escapeOtherCharactersRegex: Will escape other type of characters via regex. List-like constructions, for example `123)`

I think it's a better approach than the previous one and sets the path for future escaping necessities. What do you think?

This will solve #67, #65 and #64