### PR TITLE
Added tests for spaces in void elements (#113)

### DIFF
--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -35,7 +35,9 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown("test\nanother line", 'test another line');
         $this->html_gives_markdown("<p>test\nanother line</p>", 'test another line');
         $this->html_gives_markdown('<p>test<br>another line</p>', "test  \nanother line");
+        $this->html_gives_markdown('<p>test<br/>another line</p>', "test  \nanother line");
         $this->html_gives_markdown('<p>test<br />another line</p>', "test  \nanother line");
+        $this->html_gives_markdown('<p>test<br  />another line</p>', "test  \nanother line");
     }
 
     public function test_headers()
@@ -101,6 +103,9 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
     public function test_horizontal_rule()
     {
         $this->html_gives_markdown('<hr>', '- - - - - -');
+        $this->html_gives_markdown('<hr/>', '- - - - - -');
+        $this->html_gives_markdown('<hr />', '- - - - - -');
+        $this->html_gives_markdown('<hr  />', '- - - - - -');
     }
 
     public function test_lists()


### PR DESCRIPTION
Fixes #113. Please see that issue for more details. Technically, `img` is a [void element](http://w3c.github.io/html-reference/syntax.html#void-element) as well, but that's a special case in Markdown. I haven't looked into image handling too deeply yet, but someone finds a breaking test for spacing inside `img` elements in the immediate future, it might be a good idea to incorporate it into this PR.