### PR TITLE
Added hard_break option for GFM line breaks (#112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,21 @@ $html = '<em>Italic</em> and a <strong>bold</strong>';
 $markdown = $converter->convert($html); // $markdown now contains "_Italic_ and a __bold__"
 ```
 
+### Line break options
+
+By default, `br` tags are converted to two spaces followed by a newline character as per [traditional Markdown](https://daringfireball.net/projects/markdown/syntax#p). Set `hard_break` to `true` to omit the two spaces, as per GitHub Flavored Markdown (GFM).
+
+```php
+$converter = new HtmlConverter();
+$html = '<p>test<br>line break</p>';
+
+$converter->getConfig()->setOption('hard_break', true);
+$markdown = $converter->convert($html); // $markdown now contains "test\nline break"
+
+$converter->getConfig()->setOption('hard_break', false); // default
+$markdown = $converter->convert($html); // $markdown now contains "test  \nline break"
+```
+
 ### Limitations
 
 - Markdown Extra, MultiMarkdown and other variants aren't supported – just Markdown.

--- a/src/Converter/HardBreakConverter.php
+++ b/src/Converter/HardBreakConverter.php
@@ -2,10 +2,25 @@
 
 namespace League\HTMLToMarkdown\Converter;
 
+use League\HTMLToMarkdown\Configuration;
+use League\HTMLToMarkdown\ConfigurationAwareInterface;
 use League\HTMLToMarkdown\ElementInterface;
 
-class HardBreakConverter implements ConverterInterface
+class HardBreakConverter implements ConverterInterface, ConfigurationAwareInterface
 {
+    /**
+     * @var Configuration
+     */
+    protected $config;
+
+    /**
+     * @param Configuration $config
+     */
+    public function setConfig(Configuration $config)
+    {
+        $this->config = $config;
+    }
+
     /**
      * @param ElementInterface $element
      *
@@ -13,7 +28,7 @@ class HardBreakConverter implements ConverterInterface
      */
     public function convert(ElementInterface $element)
     {
-        return "  \n";
+        return $this->config->getOption('hard_break') ? "\n" : "  \n";
     }
 
     /**

--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -35,6 +35,7 @@ class HtmlConverter
             'bold_style'      => '**', // Set to '__' if you prefer the underlined style
             'italic_style'    => '_', // Set to '*' if you prefer the asterisk style
             'remove_nodes'    => '', // space-separated list of dom nodes that should be removed. example: 'meta style script'
+            'hard_break'      => false, // Set to true to turn <br> into `\n` instead of `  \n`
         );
 
         $this->environment = Environment::createDefaultEnvironment($defaults);

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -38,6 +38,10 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown('<p>test<br/>another line</p>', "test  \nanother line");
         $this->html_gives_markdown('<p>test<br />another line</p>', "test  \nanother line");
         $this->html_gives_markdown('<p>test<br  />another line</p>', "test  \nanother line");
+        $this->html_gives_markdown('<p>test<br>another line</p>', "test\nanother line", array('hard_break' => true));
+        $this->html_gives_markdown('<p>test<br/>another line</p>', "test\nanother line", array('hard_break' => true));
+        $this->html_gives_markdown('<p>test<br />another line</p>', "test\nanother line", array('hard_break' => true));
+        $this->html_gives_markdown('<p>test<br  />another line</p>', "test\nanother line", array('hard_break' => true));
     }
 
     public function test_headers()


### PR DESCRIPTION
Fixes #112. Please see that issue for more details. Adds `hard_break` config option. By default, it is set to `false`, which will cause `br` tags to be converted to two spaces followed by a newline character, preserving current behavior. When `hard_break` is set to `true`, those two spaces will be omitted, as per GitHub Flavored Markdown. `README.md` has been updated, new tests added, and everything seems to be in order.