### PR TITLE
Fix phantom space when newline follows br (#116)

### DIFF
--- a/src/Converter/TextConverter.php
+++ b/src/Converter/TextConverter.php
@@ -13,11 +13,15 @@ class TextConverter implements ConverterInterface
      */
     public function convert(ElementInterface $element)
     {
-        $value = $element->getValue();
+        $markdown = $element->getValue();
 
-        $markdown = preg_replace('~\s+~u', ' ', $value);
+        // Remove leftover \n at the beginning of the line
+        $markdown = ltrim($markdown, "\n");
 
-        //escape the following characters: '*', '_' and '\'
+        // Replace sequences of invisible characters with spaces
+        $markdown = preg_replace('~\s+~u', ' ', $markdown);
+
+        // Escape the following characters: '*', '_' and '\'
         $markdown = preg_replace('~([*_\\\\])~u', '\\\\$1', $markdown);
 
         $markdown = preg_replace('~^#~u', '\\\\#', $markdown);

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -34,6 +34,9 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
     {
         $this->html_gives_markdown("test\nanother line", 'test another line');
         $this->html_gives_markdown("<p>test\nanother line</p>", 'test another line');
+        $this->html_gives_markdown("<p>test<br>\nanother line</p>", "test  \nanother line");
+        $this->html_gives_markdown("<p>test<br>\n another line</p>", "test  \n another line");
+        $this->html_gives_markdown("<p>test<br>\n<em>another</em> line</p>", "test  \n_another_ line");
         $this->html_gives_markdown('<p>test<br>another line</p>', "test  \nanother line");
         $this->html_gives_markdown('<p>test<br/>another line</p>', "test  \nanother line");
         $this->html_gives_markdown('<p>test<br />another line</p>', "test  \nanother line");


### PR DESCRIPTION
Fixes #116. Please see that issue for more information. Added three new tests. Linted related code a bit in `TextConverter.php` for clarity and ease of future changes. All tests succeed. Related to #14.

This is a bit brute-force, I'll admit. I hope this can be incorporated as-is until further fail cases can be added in the form of tests. Everything seems to be in order for the time being.