### PR TITLE
Allow to inject Environment object

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,25 @@ $converter->getConfig()->setOption('hard_break', false); // default
 $markdown = $converter->convert($html); // $markdown now contains "test  \nline break"
 ```
 
+### Passing custom Environment object
+
+You can pass current `Environment` object to customize i.e. which converters should be used.
+
+```php
+$environment = new Environment(array(
+    'converters' => array(
+        new HeaderConverter(),
+    ),
+));
+
+$converter = new HtmlConverter($environment);
+
+$html = '<h3>Header</h3>
+<img src="" />
+';
+$markdown = $converter->convert($html); // $markdown now contains "### Header" and "<img src="" />"
+```
+
 ### Limitations
 
 - Markdown Extra, MultiMarkdown and other variants aren't supported – just Markdown.

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -35,6 +35,13 @@ final class Environment
     public function __construct(array $config = array())
     {
         $this->config = new Configuration($config);
+
+        if (isset($config['converters'])) {
+            foreach ($config['converters'] as $converter) {
+                $this->addConverter($converter);
+            }
+        }
+
         $this->addConverter(new DefaultConverter());
     }
 

--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -24,23 +24,27 @@ class HtmlConverter
     /**
      * Constructor
      *
-     * @param array $options Configuration options
+     * @param Environment|array $options Environment object or configuration options
      */
-    public function __construct(array $options = array())
+    public function __construct($options = array())
     {
-        $defaults = array(
-            'header_style'    => 'setext', // Set to 'atx' to output H1 and H2 headers as # Header1 and ## Header2
-            'suppress_errors' => true, // Set to false to show warnings when loading malformed HTML
-            'strip_tags'      => false, // Set to true to strip tags that don't have markdown equivalents. N.B. Strips tags, not their content. Useful to clean MS Word HTML output.
-            'bold_style'      => '**', // Set to '__' if you prefer the underlined style
-            'italic_style'    => '_', // Set to '*' if you prefer the asterisk style
-            'remove_nodes'    => '', // space-separated list of dom nodes that should be removed. example: 'meta style script'
-            'hard_break'      => false, // Set to true to turn <br> into `\n` instead of `  \n`
-        );
+        if ($options instanceof Environment) {
+            $this->environment = $options;
+        } elseif (is_array($options)) {
+            $defaults = array(
+                'header_style' => 'setext', // Set to 'atx' to output H1 and H2 headers as # Header1 and ## Header2
+                'suppress_errors' => true, // Set to false to show warnings when loading malformed HTML
+                'strip_tags' => false, // Set to true to strip tags that don't have markdown equivalents. N.B. Strips tags, not their content. Useful to clean MS Word HTML output.
+                'bold_style' => '**', // Set to '__' if you prefer the underlined style
+                'italic_style' => '_', // Set to '*' if you prefer the asterisk style
+                'remove_nodes' => '', // space-separated list of dom nodes that should be removed. example: 'meta style script'
+                'hard_break' => false,// Set to true to turn <br> into `\n` instead of `  \n`
+            );
 
-        $this->environment = Environment::createDefaultEnvironment($defaults);
+            $this->environment = Environment::createDefaultEnvironment($defaults);
 
-        $this->environment->getConfig()->merge($options);
+            $this->environment->getConfig()->merge($options);
+        }
     }
 
     /**

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace League\HTMLToMarkdown\Test;
+
+use League\HTMLToMarkdown\Converter\HeaderConverter;
+use League\HTMLToMarkdown\Environment;
+
+class EnvironmentTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_creation_with_converters()
+    {
+        $environment = new Environment(array(
+            'converters' => array(
+                new HeaderConverter(),
+            ),
+        ));
+
+        $this->assertInstanceOf(
+            'League\HTMLToMarkdown\Converter\HeaderConverter',
+            $environment->getConverterByTag('h3')
+        );
+        $this->assertInstanceOf(
+            'League\HTMLToMarkdown\Converter\DefaultConverter',
+            $environment->getConverterByTag('img')
+        );
+    }
+
+    public function test_creation()
+    {
+        $environment = Environment::createDefaultEnvironment();
+
+        $this->assertInstanceOf(
+            'League\HTMLToMarkdown\Converter\HeaderConverter',
+            $environment->getConverterByTag('h3')
+        );
+        $this->assertInstanceOf(
+            'League\HTMLToMarkdown\Converter\ImageConverter',
+            $environment->getConverterByTag('img')
+        );
+    }
+}

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -2,6 +2,7 @@
 
 namespace League\HTMLToMarkdown\Test;
 
+use League\HTMLToMarkdown\Environment;
 use League\HTMLToMarkdown\HtmlConverter;
 
 class HtmlConverterTest extends \PHPUnit_Framework_TestCase
@@ -236,5 +237,18 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown("<p>123456789) Foo and 1234567890) Bar!</p>\n<p>1. Platz in 'Das große Backen'</p>", "123456789\\) Foo and 1234567890) Bar!\n\n1\\. Platz in 'Das große Backen'");
         $this->html_gives_markdown("<p>\n+ Siri works well for TV and movies<br>\n- No 4K support\n</p>", "\+ Siri works well for TV and movies  \n\- No 4K support");
         $this->html_gives_markdown('<p>You forgot the &lt;!--more--&gt; tag!</p>', 'You forgot the \<!--more--> tag!');
+    }
+
+    public function test_instatiation_with_environment()
+    {
+        $markdown = new HtmlConverter(new Environment(array()));
+
+        $htmlH3 = '<h3>Test</h3>';
+        $result = $markdown->convert($htmlH3);
+        $this->assertEquals($htmlH3, $result);
+
+        $htmlH4 = '<h4>Test</h4>';
+        $result = $markdown->convert($htmlH4);
+        $this->assertEquals($htmlH4, $result);
     }
 }


### PR DESCRIPTION
I need to customize rules, because I'm using modified Markdown, with couple of custom rules. I decided to prepare a logic for inject Environment object to HtmlConverter, so I am now able to change converters. Also it is easier to refactor tests to make them unit, because now test cases runs all the logic from library.
I tried not to break BC, but I would appreciate your review, if I didn't miss some important cases.