### PR TITLE
Trim the link text to avoid incorrect syntax

### DIFF
--- a/src/Converter/LinkConverter.php
+++ b/src/Converter/LinkConverter.php
@@ -15,7 +15,7 @@ class LinkConverter implements ConverterInterface
     {
         $href = $element->getAttribute('href');
         $title = $element->getAttribute('title');
-        $text = $element->getValue();
+        $text = trim($element->getValue());
 
         if ($title !== '') {
             $markdown = '[' . $text . '](' . $href . ' "' . $title . '")';


### PR DESCRIPTION
This solves issue #119.

It's just a `trim()` function over the link text.