### PR TITLE
Fix: Add missing throws annotation

### DIFF
--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -84,6 +84,8 @@ class HtmlConverter
      *
      * @param $html
      *
+     * @throws \InvalidArgumentException
+     *
      * @return string The Markdown version of the html
      */
     public function convert($html)


### PR DESCRIPTION
This PR

* [x] adds a missing `@throws` annotation