### PR TITLE
Fix: Update docblocks

### DIFF
--- a/src/Element.php
+++ b/src/Element.php
@@ -126,6 +126,7 @@ class Element implements ElementInterface
 
     /**
      * @param \DomNode $node
+     * @param bool $checkChildren
      *
      * @return \DomNode|null
      */

--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -82,7 +82,7 @@ class HtmlConverter
      *
      * Loads HTML and passes to getMarkdown()
      *
-     * @param $html
+     * @param string $html
      *
      * @return string The Markdown version of the html
      */


### PR DESCRIPTION
This PR

* [x] adds a method argument to a docblock and adds a missing type