### PR TITLE
Escape square brackets

### DIFF
--- a/src/Converter/TextConverter.php
+++ b/src/Converter/TextConverter.php
@@ -21,8 +21,8 @@ class TextConverter implements ConverterInterface
         // Replace sequences of invisible characters with spaces
         $markdown = preg_replace('~\s+~u', ' ', $markdown);
 
-        // Escape the following characters: '*', '_' and '\'
-        $markdown = preg_replace('~([*_\\\\])~u', '\\\\$1', $markdown);
+        // Escape the following characters: '*', '_', '[', ']' and '\'
+        $markdown = preg_replace('~([*_\\[\\]\\\\])~u', '\\\\$1', $markdown);
 
         $markdown = preg_replace('~^#~u', '\\\\#', $markdown);
 

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -29,6 +29,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown('<p>*test*</p>', '\\*test\\*'); // \*test\*
         $this->html_gives_markdown('<p>_test_</p>', '\\_test\\_'); // \_test\_
         $this->html_gives_markdown('<p>\\*test\\*</p>', '\\\\\\*test\\\\\\*'); // \\\*test\\\*
+        $this->html_gives_markdown('<p>test[test]</p>', 'test\\[test\\]'); // test\[test\]
     }
 
     public function test_line_breaks()


### PR DESCRIPTION
Escapes the characters '[' and ']' on text elements so that

```
<p>test[test]</p>
```

gets converted to

```
test\[test\]
```