### PR TITLE
Line break inside formatting tag kills markdown

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,9 @@
         "mikehaertl/php-shellcommand": "~1.1.0",
         "phpunit/phpunit": "4.*",
         "scrutinizer/ocular": "~1.1"
+    },    
+    "scripts": {
+        "test": "phpunit"
     },
     "bin": ["bin/html-to-markdown"],
     "extra": {

--- a/src/Converter/HardBreakConverter.php
+++ b/src/Converter/HardBreakConverter.php
@@ -28,6 +28,7 @@ class HardBreakConverter implements ConverterInterface, ConfigurationAwareInterf
      */
     public function convert(ElementInterface $element)
     {
+        if (in_array($element->getParent()->getTagName(),array('i','u','b','em','strong','h1', 'h2', 'h3', 'h4', 'h5', 'h6'))) return ' ';
         return $this->config->getOption('hard_break') ? "\n" : "  \n";
     }
 

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -47,6 +47,8 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown('<p>test<br/>another line</p>', "test\nanother line", array('hard_break' => true));
         $this->html_gives_markdown('<p>test<br />another line</p>', "test\nanother line", array('hard_break' => true));
         $this->html_gives_markdown('<p>test<br  />another line</p>', "test\nanother line", array('hard_break' => true));
+        $this->html_gives_markdown('<p>test breaks <b>inside<br>bold</b> <strong>inside<br>bold</strong> tag</p>', "test breaks **inside bold** **inside bold** tag");
+        $this->html_gives_markdown('<p>test breaks <i>inside<br>emphasis</i> <em>inside<br>emphasis</em> tag</p>', "test breaks _inside emphasis_ _inside emphasis_ tag");
     }
 
     public function test_headers()
@@ -59,6 +61,12 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown('<h4>Test</h4>', '#### Test');
         $this->html_gives_markdown('<h5>Test</h5>', '##### Test');
         $this->html_gives_markdown('<h6>Test</h6>', '###### Test');
+        $this->html_gives_markdown('<h1>break in<br>header</h1>', "break in header\n===============");
+        $this->html_gives_markdown('<h2>break in<br>header</h2>', "break in header\n---------------");
+        $this->html_gives_markdown('<h3>break in<br>header</h3>', "### break in header");
+        $this->html_gives_markdown('<h4>break in<br>header</h4>', "#### break in header");
+        $this->html_gives_markdown('<h5>break in<br>header</h5>', "##### break in header");
+        $this->html_gives_markdown('<h6>break in<br>header</h6>', "###### break in header");
     }
 
     public function test_spans()


### PR DESCRIPTION
First of all, thank you for very flexible library!

I found small problem. Converting HTML `<p><b>This<br>tag</b> will break the markup</p>` gives markdown that can't be displayed correctly

```
**This 
tag** will break the markup
```

My pull request allows to avoid such problem inside of some formatting tags (b, i, h1, h2...). Added necessary tests.