### PR TITLE
Add 2 x new line after converting <pre> tags

### DIFF
--- a/src/Converter/CodeConverter.php
+++ b/src/Converter/CodeConverter.php
@@ -43,7 +43,7 @@ class CodeConverter implements ConverterInterface
         $lines = preg_split('/\r\n|\r|\n/', $code);
         if (count($lines) > 1) {
             // Multiple lines detected, adding three backticks and newlines
-            $markdown .= '```' . $language . "\n" . $code . "\n" . '```';
+            $markdown .= "```" . $language . "\n" . $code . "\n" . "```\n\n";
         } else {
             // One line of code, wrapping it on one backtick.
             $markdown .= '`' . $language . $code . '`';

--- a/src/Converter/PreformattedConverter.php
+++ b/src/Converter/PreformattedConverter.php
@@ -40,7 +40,7 @@ class PreformattedConverter implements ConverterInterface
         $lines = preg_split('/\r\n|\r|\n/', $pre_content);
         if (count($lines) > 1) {
             // Multiple lines detected, adding three backticks and newlines
-            $markdown .= '```' . "\n" . $pre_content . "\n" . '```';
+            $markdown .= "```" . "\n" . $pre_content . "\n" . "```\n\n";
         } else {
             // One line of code, wrapping it on one backtick.
             $markdown .= '`' . $pre_content . '`';

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -161,6 +161,8 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown('<pre><code class="language-php">&lt;?php //Some php code ?&gt;</code></pre>', '`php <?php //Some php code ?>`');
         $this->html_gives_markdown("<pre><code class=\"language-php\">&lt;?php //Some multiline php code\n\$myVar = 2; ?&gt;</code></pre>", "```php \n<?php //Some multiline php code\n\$myVar = 2; ?>\n```");
         $this->html_gives_markdown("<pre><code>&lt;p&gt;Multiline HTML&lt;/p&gt;\n&lt;p&gt;Here's the second line&lt;/p&gt;</code></pre>", "```\n<p>Multiline HTML</p>\n<p>Here's the second line</p>\n```");
+        $this->html_gives_markdown("<pre><code>&lt;p&gt;Multiline HTML&lt;/p&gt;\n&lt;p&gt;Here's the second line&lt;/p&gt;</code></pre>\n<p>line</p>", "```\n<p>Multiline HTML</p>\n<p>Here's the second line</p>\n```" . PHP_EOL . PHP_EOL . "line");
+        
     }
 
     public function test_preformat()
@@ -168,6 +170,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown("<pre>test\ntest\r\ntest</pre>", "```\ntest" . PHP_EOL . 'test' . PHP_EOL . "test\n```");
         $this->html_gives_markdown("<pre>test\n\ttab\r\n</pre>", "```\ntest" . PHP_EOL . "\ttab" . PHP_EOL . "\n```");
         $this->html_gives_markdown('<pre>  one line with spaces  </pre>', '`  one line with spaces  `');
+        $this->html_gives_markdown("<pre>one\ntwo\r\nthree</pre>\n<p>line</p>", "```\none" . PHP_EOL . 'two' . PHP_EOL . "three\n```" . PHP_EOL . PHP_EOL . "line");
     }
 
     public function test_blockquotes()


### PR DESCRIPTION
Thanks for this incredibly useful code. 

I've been converting lots of HTML with code snippets and come across the following: All the other block level elements apart from `<pre>` are followed by \n\n when they are converted. 

This is inconsistent and it also seems that the resulting markdown doesn't get converted back to HTML consistently in different parsers.

Therefore when a multiline `<pre>` or `<pre><code>` is converted to ``` I've added \n\n afterwards.

Cheers