### PR TITLE
Created setOptions function for chainable calling

### DIFF
--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -229,4 +229,23 @@ class HtmlConverter
 
         return trim($markdown, "\n\r\0\x0B");
     }
+    
+    /**
+     * Pass a series of key-value pairs in an array; these will be passed
+     * through the config and set.
+     * The advantage of this is that it can allow for static use (IE in Laravel).
+     * An example being:
+     * 
+     * HtmlConverter::setOptions(['strip_tags' => true])->convert('<h1>test</h1>');
+     */
+    public function setOptions(array $options)
+    {
+        $config = $this->getConfig();
+
+        foreach ($options as $key => $option) {
+            $config->setOption($key, $option);
+        }
+
+        return $this;
+    }
 }


### PR DESCRIPTION
I have created a new function that allows an easier way of static calling.
I am using Laravel and decided to use the Facade feature as so:

    use Facades\League\HTMLToMarkdown\HtmlConverter as Markup;

    $converted = Markup::setOptions(['strip_tags' => true])->convert('<span>Turnips!</span>');

The `setOptions` function made it possible to call the library in one line.