### PR TITLE
<code> tags are blocks if inside <pre>, inline otherwise

### DIFF
--- a/src/Converter/CodeConverter.php
+++ b/src/Converter/CodeConverter.php
@@ -13,7 +13,7 @@ class CodeConverter implements ConverterInterface
      */
     public function convert(ElementInterface $element)
     {
-        $language = null;
+        $language = '';
 
         // Checking for language class on the code block
         $classes = $element->getAttribute('class');
@@ -24,8 +24,7 @@ class CodeConverter implements ConverterInterface
             foreach ($classes as $class) {
                 if (strpos($class, 'language-') !== false) {
                     // Found one, save it as the selected language and stop looping over the classes.
-                    // The space after the language avoids gluing the actual code with the language tag
-                    $language = str_replace('language-', '', $class) . ' ';
+                    $language = str_replace('language-', '', $class);
                     break;
                 }
             }
@@ -39,14 +38,13 @@ class CodeConverter implements ConverterInterface
         $code = preg_replace('/<code\b[^>]*>/', '', $code);
         $code = str_replace('</code>', '', $code);
 
-        // Checking if the code has multiple lines
-        $lines = preg_split('/\r\n|\r|\n/', $code);
-        if ($language || count($lines) > 1) {
-            // Multiple lines detected, adding three backticks and newlines
-            $markdown .= '```' . $language . "\n" . $code . "\n" . '```' . "\n\n";
+        // Checking if it's a code block or span
+        if ($element->getParent()->getTagName() == 'pre') {
+            // Code block detected, newlines will be added in parent
+            $markdown .= '```' . $language . "\n" . $code . "\n" . '```';
         } else {
-            // One line of code, wrapping it on one backtick.
-            $markdown .= '`' . $language . $code . '`';
+            // One line of code, wrapping it on one backtick, removing new lines
+            $markdown .= '`' . preg_replace('/\r\n|\r|\n/', '', $code) . '`';
         }
 
         return $markdown;

--- a/src/Converter/PreformattedConverter.php
+++ b/src/Converter/PreformattedConverter.php
@@ -26,23 +26,17 @@ class PreformattedConverter implements ConverterInterface
         $firstBacktick = strpos(trim($pre_content), '`');
         $lastBacktick = strrpos(trim($pre_content), '`');
         if ($firstBacktick === 0 && $lastBacktick === strlen(trim($pre_content)) - 1) {
-            return $pre_content;
+            return $pre_content . "\n\n";
         }
 
         // If the execution reaches this point it means it's just a pre tag, with no code tag nested
 
         // Empty lines are a special case
         if ($pre_content === '') {
-            return "```\n```\n";
+            return "```\n```\n\n";
         }
 
         // Normalizing new lines
-
-        // Is it a single line?
-        if (strpos($pre_content, PHP_EOL) === false) {
-            // One line of code, wrapping it on one backtick.
-            return '`' . $pre_content . '`';
-        }
         $pre_content = preg_replace('/\r\n|\r|\n/', "\n", $pre_content);
 
         // Ensure there's a newline at the end

--- a/src/Converter/PreformattedConverter.php
+++ b/src/Converter/PreformattedConverter.php
@@ -37,17 +37,17 @@ class PreformattedConverter implements ConverterInterface
         }
 
         // Normalizing new lines
-        $pre_content = preg_replace('/\r\n|\r|\n/', PHP_EOL, $pre_content);
 
         // Is it a single line?
         if (strpos($pre_content, PHP_EOL) === false) {
             // One line of code, wrapping it on one backtick.
             return '`' . $pre_content . '`';
         }
+        $pre_content = preg_replace('/\r\n|\r|\n/', "\n", $pre_content);
 
         // Ensure there's a newline at the end
-        if (strrpos($pre_content, PHP_EOL) !== strlen($pre_content) - 1) {
-            $pre_content .= PHP_EOL;
+        if (strrpos($pre_content, "\n") !== strlen($pre_content) - strlen("\n")) {
+            $pre_content .= "\n";
         }
 
         // Use three backticks

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -173,20 +173,20 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
 
     public function test_preformat()
     {
-        $this->html_gives_markdown("<pre>test\ntest\r\ntest</pre>", "```\ntest" . PHP_EOL .'test'. PHP_EOL .'test'. PHP_EOL .'```');
-        $this->html_gives_markdown("<pre>test\ntest\r\ntest\n</pre>", "```\ntest" . PHP_EOL .'test'. PHP_EOL .'test'. PHP_EOL .'```');
-        $this->html_gives_markdown("<pre>test\n\ttab\r\n</pre>", "```\ntest" . PHP_EOL . "\ttab" . PHP_EOL . '```');
-        $this->html_gives_markdown('<pre>  one line with spaces  </pre>', '`  one line with spaces  `');
+        $this->html_gives_markdown("<pre>test\ntest\r\ntest</pre>", "```\ntest\ntest\ntest\n```");
+        $this->html_gives_markdown("<pre>test\ntest\r\ntest\n</pre>", "```\ntest\ntest\ntest\n```");
+        $this->html_gives_markdown("<pre>test\n\ttab\r\n</pre>", "```\ntest\n" . "\ttab\n```");
+        $this->html_gives_markdown('<pre>  one line with spaces  </pre>', "```\n  one line with spaces  \n```");
         $this->html_gives_markdown("<pre></pre>", "```\n```");
-        $this->html_gives_markdown("<pre></pre><pre></pre>", "```\n```\n```\n```");
-        $this->html_gives_markdown("<pre>\n</pre>", "```\n" . PHP_EOL . '```');
-        $this->html_gives_markdown("<pre>foo\n</pre>", "```\nfoo" . PHP_EOL . '```');
-        $this->html_gives_markdown("<pre>\nfoo</pre>", "```\n" . PHP_EOL . 'foo' . PHP_EOL . '```');
-        $this->html_gives_markdown("<pre>\nfoo\n</pre>", "```\n" . PHP_EOL . 'foo' . PHP_EOL . '```');
-        $this->html_gives_markdown("<pre>\n\n</pre>", "```\n" . PHP_EOL . PHP_EOL . '```');
-        $this->html_gives_markdown("<pre>\n\n\n</pre>", "```\n" . PHP_EOL . PHP_EOL . PHP_EOL . '```');
-        $this->html_gives_markdown("<pre>\n</pre><pre>\n</pre>", "```\n" . PHP_EOL. "```\n\n```\n" . PHP_EOL . '```');
-        $this->html_gives_markdown("<pre>one\ntwo\r\nthree</pre>\n<p>line</p>", "```\none" . PHP_EOL . 'two' . PHP_EOL . "three\n```" . PHP_EOL . PHP_EOL . "line");
+        $this->html_gives_markdown("<pre></pre><pre></pre>", "```\n```\n\n```\n```");
+        $this->html_gives_markdown("<pre>\n</pre>", "```\n\n```");
+        $this->html_gives_markdown("<pre>foo\n</pre>", "```\nfoo\n```");
+        $this->html_gives_markdown("<pre>\nfoo</pre>", "```\n\nfoo\n```");
+        $this->html_gives_markdown("<pre>\nfoo\n</pre>", "```\n\nfoo\n```");
+        $this->html_gives_markdown("<pre>\n\n</pre>", "```\n\n\n```");
+        $this->html_gives_markdown("<pre>\n\n\n</pre>", "```\n\n\n\n```");
+        $this->html_gives_markdown("<pre>\n</pre><pre>\n</pre>", "```\n\n```\n\n```\n\n```");
+        $this->html_gives_markdown("<pre>one\ntwo\r\nthree</pre>\n<p>line</p>", "```\none\ntwo\nthree\n```\n\nline");
     }
 
     public function test_blockquotes()

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -160,15 +160,15 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
     public function test_code_samples()
     {
         $this->html_gives_markdown('<code>&lt;p&gt;Some sample HTML&lt;/p&gt;</code>', '`<p>Some sample HTML</p>`');
-        $this->html_gives_markdown("<code>\n&lt;p&gt;Some sample HTML&lt;/p&gt;\n&lt;p&gt;And another line&lt;/p&gt;\n</code>", "```\n\n<p>Some sample HTML</p>\n<p>And another line</p>\n\n```");
-        $this->html_gives_markdown("<code>\n&lt;p&gt;Some sample HTML&lt;/p&gt;\n&lt;p&gt;And another line&lt;/p&gt;\n</code><p>Paragraph after code.</p>", "```\n\n<p>Some sample HTML</p>\n<p>And another line</p>\n\n```\n\nParagraph after code.");
-        $this->html_gives_markdown("<p><code>\n#sidebar h1 {\n    font-size: 1.5em;\n    font-weight: bold;\n}\n</code></p>", "```\n\n#sidebar h1 {\n    font-size: 1.5em;\n    font-weight: bold;\n}\n\n```");
-        $this->html_gives_markdown("<p><code>#sidebar h1 {\n    font-size: 1.5em;\n    font-weight: bold;\n}\n</code></p>", "```\n#sidebar h1 {\n    font-size: 1.5em;\n    font-weight: bold;\n}\n\n```");
-        $this->html_gives_markdown('<pre><code>&lt;p&gt;Some sample HTML&lt;/p&gt;</code></pre>', '`<p>Some sample HTML</p>`');
-        $this->html_gives_markdown('<pre><code class="language-php">&lt;?php //Some php code ?&gt;</code></pre>', "```php \n<?php //Some php code ?>\n```");
-        $this->html_gives_markdown("<pre><code class=\"language-php\">&lt;?php //Some multiline php code\n\$myVar = 2; ?&gt;</code></pre>", "```php \n<?php //Some multiline php code\n\$myVar = 2; ?>\n```");
+        $this->html_gives_markdown("<code>\n&lt;p&gt;Some sample HTML&lt;/p&gt;\n&lt;p&gt;And another line&lt;/p&gt;\n</code>", "`<p>Some sample HTML</p><p>And another line</p>`");
+        $this->html_gives_markdown("<p><code>\n&lt;p&gt;Some sample HTML&lt;/p&gt;\n&lt;p&gt;And another line&lt;/p&gt;\n</code></p><p>Paragraph after code.</p>", "`<p>Some sample HTML</p><p>And another line</p>`\n\nParagraph after code.");
+        $this->html_gives_markdown("<p><code>\n#sidebar h1 {\n    font-size: 1.5em;\n    font-weight: bold;\n}\n</code></p>", "`#sidebar h1 {    font-size: 1.5em;    font-weight: bold;}`");
+        $this->html_gives_markdown("<p><code>#sidebar h1 {\n    font-size: 1.5em;\n    font-weight: bold;\n}\n</code></p>", "`#sidebar h1 {    font-size: 1.5em;    font-weight: bold;}`");
+        $this->html_gives_markdown('<pre><code>&lt;p&gt;Some sample HTML&lt;/p&gt;</code></pre>', "```\n<p>Some sample HTML</p>\n```");
+        $this->html_gives_markdown('<pre><code class="language-php">&lt;?php //Some php code ?&gt;</code></pre>', "```php\n<?php //Some php code ?>\n```");
+        $this->html_gives_markdown("<pre><code class=\"language-php\">&lt;?php //Some multiline php code\n\$myVar = 2; ?&gt;</code></pre>", "```php\n<?php //Some multiline php code\n\$myVar = 2; ?>\n```");
         $this->html_gives_markdown("<pre><code>&lt;p&gt;Multiline HTML&lt;/p&gt;\n&lt;p&gt;Here's the second line&lt;/p&gt;</code></pre>", "```\n<p>Multiline HTML</p>\n<p>Here's the second line</p>\n```");
-        $this->html_gives_markdown("<pre><code>&lt;p&gt;Multiline HTML&lt;/p&gt;\n&lt;p&gt;Here's the second line&lt;/p&gt;</code></pre>\n<p>line</p>", "```\n<p>Multiline HTML</p>\n<p>Here's the second line</p>\n```" . PHP_EOL . PHP_EOL . "line");
+        $this->html_gives_markdown("<pre><code>&lt;p&gt;Multiline HTML&lt;/p&gt;\n&lt;p&gt;Here's the second line&lt;/p&gt;</code></pre>\n<p>line</p>", "```\n<p>Multiline HTML</p>\n<p>Here's the second line</p>\n```\n\nline");
     }
 
     public function test_preformat()
@@ -265,7 +265,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
     public function test_sanitization()
     {
         $html = '<pre><code>&lt;script type = "text/javascript"&gt; function startTimer() { var tim = window.setTimeout("hideMessage()", 5000) } &lt;/head&gt; &lt;body&gt;</code></pre>';
-        $markdown = '`<script type = "text/javascript"> function startTimer() { var tim = window.setTimeout("hideMessage()", 5000) } </head> <body>`';
+        $markdown = '```' . "\n" . '<script type = "text/javascript"> function startTimer() { var tim = window.setTimeout("hideMessage()", 5000) } </head> <body>' . "\n```";
         $this->html_gives_markdown($html, $markdown);
         $this->html_gives_markdown('<p>&gt; &gt; Look at me! &lt; &lt;</p>', '\> > Look at me! < <');
         $this->html_gives_markdown('<p>&gt; &gt; <b>Look</b> at me! &lt; &lt;<br />&gt; Just look at me!</p>', "\\> > **Look** at me! < <  \n\\> Just look at me!");


### PR DESCRIPTION
Fixes #26
Fixes #70
Undoes most incompatible behavior of #102
Fixes #140
Fixes #161
Blocks https://github.com/friendica/friendica/pull/5765#issuecomment-422097903

Per the CommonMark spec, single backtick (inline) code blocks produce `<p><code>....</code></p>` tags without honoring new lines, while multiple backtick (block) code blocks produce `<pre><code>...</code></pre>` tags, keeping new lines.

Going the other way, we should only convert to a multiple-backticks code block if the `<code>` tag is inside a `<pre>` tag. By himself, a HTML `<code>` tag is inline and doesn't show new lines, only the `<pre>` tag confers this ability.

This PR also removes references to `PHP_EOL` where `\n` was mostly used.

Tests have been updated.