### PR TITLE
Fix #165: Paragraph after table.

### DIFF
--- a/src/Converter/DefaultConverter.php
+++ b/src/Converter/DefaultConverter.php
@@ -37,7 +37,13 @@ class DefaultConverter implements ConverterInterface, ConfigurationAwareInterfac
             return $element->getValue();
         }
 
-        return html_entity_decode($element->getChildrenAsString());
+        $markdown = html_entity_decode($element->getChildrenAsString());
+
+        if ($element->getTagName() === 'table') {
+            $markdown .= "\n\n";
+        }
+
+        return $markdown;
     }
 
     /**


### PR DESCRIPTION
This PR includes a fix for #165.

I'm not sure if there are other cases that would rely on a similar handling, but I'm dealing with the paragraph after table situation. Since this is a unique case, I don't think we need to move the `$element->getTagName() === 'table'` condition to a separate method. I'm open to refactoring that if it's necessary.