### PR TITLE
Feature escape more characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ~*
+/.idea/
 /build/
 vendor
 composer.lock

--- a/src/Converter/TextConverter.php
+++ b/src/Converter/TextConverter.php
@@ -23,7 +23,7 @@ class TextConverter implements ConverterInterface
 
         // Escape the following characters: '*', '_', '[', ']' and '\'
         if ($element->getParent() && $element->getParent()->getTagName() !== 'div') {
-            $markdown = preg_replace('~([*_\\[\\]\\\\])~u', '\\\\$1', $markdown);
+            $markdown = preg_replace('~([\\!\\~>\\+\\-\\(\\)\\{\\}\\`#*_\\[\\]\\\\])~u', '\\\\$1', $markdown);
         }
 
         $markdown = preg_replace('~^#~u', '\\\\#', $markdown);

--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -185,12 +185,17 @@ class HtmlConverter implements HtmlConverterInterface
     {
         $tag = $element->getTagName();
 
+        $parentTag = $element->getParent()->getTagName();
+        //If this is text from a URL, we don't need to run it through the textConverter.
+        if ($parentTag === 'a' && $tag === '#text') {
+            return $element->getValue();
+        }
+
         // Strip nodes named in remove_nodes
         $tags_to_remove = explode(' ', $this->getConfig()->getOption('remove_nodes'));
         if (in_array($tag, $tags_to_remove)) {
             return false;
         }
-
         $converter = $this->environment->getConverterByTag($tag);
 
         return $converter->convert($element);

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -35,7 +35,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown('<div>_test_</div>', '<div>_test_</div>');
         $this->html_gives_markdown('<div>*test*</div>', '<div>*test*</div>');
 
-        $this->html_gives_markdown('<p>\ ` * _ { } [ ] ( ) &gt; > # + - . !</p>', '\\\\ ` \* \_ { } \[ \] ( ) > > # + - . !');
+        $this->html_gives_markdown('<p>\ ` * _ { } [ ] ( ) &gt; > # + - . !</p>', '\\\\ \` \* \_ \{ \} \[ \] \( \) \> \> \# \+ \- . \!');
     }
 
     public function test_line_breaks()
@@ -70,7 +70,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown('<h2></h2>', '');
         $this->html_gives_markdown('<h3></h3>', '');
         $this->html_gives_markdown('<h1># Test</h1>', "\# Test\n=======");
-        $this->html_gives_markdown('<h1># Test #</h1>', "\# Test #\n=========");
+        $this->html_gives_markdown('<h1># Test #</h1>', "\# Test \#\n==========");
         $this->html_gives_markdown('<h3>Mismatched Tags</h4>', '### Mismatched Tags');
     }
 
@@ -116,7 +116,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown('<a href="http://modernnerd.net" title="Title">Modern Nerd</a>', '[Modern Nerd](http://modernnerd.net "Title")');
         $this->html_gives_markdown('<a href="http://modernnerd.net" title="Title">Modern Nerd</a> <a href="http://modernnerd.net" title="Title">Modern Nerd</a>', '[Modern Nerd](http://modernnerd.net "Title") [Modern Nerd](http://modernnerd.net "Title")');
         $this->html_gives_markdown('<a href="http://modernnerd.net"><h3>Modern Nerd</h3></a>', '[### Modern Nerd](http://modernnerd.net)');
-        $this->html_gives_markdown('The <a href="http://modernnerd.net">Modern Nerd </a>(MN)', 'The [Modern Nerd ](http://modernnerd.net)(MN)');
+        $this->html_gives_markdown('The <a href="http://modernnerd.net">Modern Nerd </a>(MN)', 'The [Modern Nerd ](http://modernnerd.net)\(MN\)');
         $this->html_gives_markdown('<a href="http://modernnerd.net/" title="Title"><img src="/path/img.jpg" alt="alt text" title="Title"/></a>', '[![alt text](/path/img.jpg "Title")](http://modernnerd.net/ "Title")');
         $this->html_gives_markdown('<a href="http://modernnerd.net/" title="Title"><img src="/path/img.jpg" alt="alt text" title="Title"/> Test</a>', '[![alt text](/path/img.jpg "Title") Test](http://modernnerd.net/ "Title")');
 
@@ -212,7 +212,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
     {
         $this->html_gives_markdown('<blockquote>Something I said?</blockquote>', '> Something I said?');
         $this->html_gives_markdown('<blockquote><blockquote>Something I said?</blockquote></blockquote>', '> > Something I said?');
-        $this->html_gives_markdown('<blockquote><p>Something I said?</p><p>Why, yes it was!</p></blockquote>', "> Something I said?\n> \n> Why, yes it was!");
+        $this->html_gives_markdown('<blockquote><p>Something I said?</p><p>Why, yes it was!</p></blockquote>', "> Something I said?\n> \n> Why, yes it was\!");
     }
 
     public function test_malformed_html()
@@ -286,14 +286,15 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<pre><code>&lt;script type = "text/javascript"&gt; function startTimer() { var tim = window.setTimeout("hideMessage()", 5000) } &lt;/head&gt; &lt;body&gt;</code></pre>';
         $markdown = '```' . "\n" . '<script type = "text/javascript"> function startTimer() { var tim = window.setTimeout("hideMessage()", 5000) } </head> <body>' . "\n```";
         $this->html_gives_markdown($html, $markdown);
-        $this->html_gives_markdown('<p>&gt; &gt; Look at me! &lt; &lt;</p>', '\> > Look at me! < <');
-        $this->html_gives_markdown('<p>&gt; &gt; <b>Look</b> at me! &lt; &lt;<br />&gt; Just look at me!</p>', "\\> > **Look** at me! < <  \n\\> Just look at me!");
-        $this->html_gives_markdown('<p>Foo<br>--<br>Bar<br>Foo--</p>', "Foo  \n\\--  \nBar  \nFoo--");
-        $this->html_gives_markdown('<ul><li>Foo<br>- Bar</li></ul>', "- Foo  \n  \\- Bar");
-        $this->html_gives_markdown('Foo<br />* Bar', "Foo  \n\\* Bar");
-        $this->html_gives_markdown("<p>123456789) Foo and 1234567890) Bar!</p>\n<p>1. Platz in 'Das große Backen'</p>", "123456789\\) Foo and 1234567890) Bar!\n\n1\\. Platz in 'Das große Backen'");
+        $this->html_gives_markdown('<p>&gt; &gt; Look at me! &lt; &lt;</p>', '\> \> Look at me\! < <');
+        $this->html_gives_markdown('<p>&gt; &gt; <b>Look</b> at me! &lt; &lt;<br />&gt; Just look at me!</p>', "\> \> **Look** at me\! < <  \n\> Just look at me\!");
+        $this->html_gives_markdown('<p>Foo<br>--<br>Bar<br>Foo--</p>', "Foo  \n\-\-  \nBar  \nFoo\-\-");
+        $this->html_gives_markdown('<ul><li>Foo<br>- Bar</li></ul>', "- Foo  \n  \\\- Bar");
+        $this->html_gives_markdown('Foo<br />* Bar', "Foo  \n\* Bar");
+        $this->html_gives_markdown("<p>123456789) Foo and 1234567890) Bar!</p>\n<p>1. Platz in 'Das große Backen'</p>", "123456789\) Foo and 1234567890\) Bar\!\n\n1\. Platz in 'Das große Backen'");
         $this->html_gives_markdown("<p>\n+ Siri works well for TV and movies<br>\n- No 4K support\n</p>", "\+ Siri works well for TV and movies  \n\- No 4K support");
-        $this->html_gives_markdown('<p>You forgot the &lt;!--more--&gt; tag!</p>', 'You forgot the \<!--more--> tag!');
+        $this->html_gives_markdown('<p>You forgot the &lt;!--more--&gt; tag!</p>', 'You forgot the <\!\-\-more\-\-\> tag\!');
+        $this->html_gives_markdown('The #cow says <h1>mooo</h1>', "The \#cow says\n\nmooo\n====");
     }
 
     public function test_instatiation_with_environment()


### PR DESCRIPTION
This pull request is to escape the markdown characters that aren't currently escaped by the textConverter.

Currently, a HTML string that contains existing characters (such as # or -) would have its formatting broken after markdown conversion due to these characters now being treated as formatting syntax.

This broke the linkConverter, which runs link text through the text converter. I couldn't see a need for this, so I've bypassed it for now with the hope that you could provide the reason it may be needed.

I appreciate that this may be considered a breaking change, if it is, would a config option work for you?