### PR TITLE
Removed `code` from the block elements list since it's inline

### DIFF
--- a/src/Element.php
+++ b/src/Element.php
@@ -27,7 +27,6 @@ class Element implements ElementInterface
         switch ($this->getTagName()) {
             case 'blockquote':
             case 'body':
-            case 'code':
             case 'div':
             case 'h1':
             case 'h2':

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -237,6 +237,11 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown('<p>Test</p><!-- Test comment -->', 'Test', array('strip_tags' => true));
     }
 
+    public function test_preserve_whitespace()
+    {
+        $this->html_gives_markdown('<a href="google.com">google.com</a> <code>test</code>', '[google.com](google.com) `test`');
+    }
+
     public function test_delete_blank_p()
     {
         $this->html_gives_markdown('<p></p>', '');


### PR DESCRIPTION
This PR removes the `code` element from the array returned by `isBlock` function because `<code>` is an inline HTML element, not a block.

Fixes #174 