### PR TITLE
Added option to preserve comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Typically you would convert HTML to Markdown if:
 
 1. You have an existing HTML document that needs to be edited by people with good taste.
 2. You want to store new content in HTML format but edit it as Markdown.
-3. You want to convert HTML email to plain text email. 
+3. You want to convert HTML email to plain text email.
 4. You know a guy who's been converting HTML to Markdown for years, and now he can speak Elvish. You'd quite like to be able to speak Elvish.
 5. You just really like Markdown.
 
@@ -93,6 +93,24 @@ $converter = new HtmlConverter(array('remove_nodes' => 'span div'));
 
 $html = '<span>Turnips!</span><div>Monkeys!</div>';
 $markdown = $converter->convert($html); // $markdown now contains ""
+```
+
+By default, all comments are stripped from the content. To preserve them, use the `preserve_comments` option, like this:
+
+```php
+$converter = new HtmlConverter(array('preserve_comments' => true));
+
+$html = '<span>Turnips!</span><!-- Monkeys! -->';
+$markdown = $converter->convert($html); // $markdown now contains "Turnips!<!-- Monkeys! -->"
+```
+
+To preserve only specific comments, set `preserve_comments` with an array of strings, like this:
+
+```php
+$converter = new HtmlConverter(array('preserve_comments' => array('Eggs!')));
+
+$html = '<span>Turnips!</span><!-- Monkeys! --><!-- Eggs! -->';
+$markdown = $converter->convert($html); // $markdown now contains "Turnips!<!-- Eggs! -->"
 ```
 
 ### Style options
@@ -161,7 +179,7 @@ $markdown = $converter->convert($html); // $markdown now contains "### Header" a
 
      Headers of H3 priority and lower always use atx style.
 
-- Links and images are referenced inline. Footnote references (where image src and anchor href attributes are listed in the footnotes) are not used. 
+- Links and images are referenced inline. Footnote references (where image src and anchor href attributes are listed in the footnotes) are not used.
 - Blockquotes aren't line wrapped – it makes the converted Markdown easier to edit.
 
 ### Dependencies
@@ -193,4 +211,3 @@ Use one of these great libraries:
  - [Parsedown](https://github.com/erusev/parsedown)
 
 No guarantees about the Elvish, though.
-

--- a/src/Converter/CommentConverter.php
+++ b/src/Converter/CommentConverter.php
@@ -2,10 +2,25 @@
 
 namespace League\HTMLToMarkdown\Converter;
 
+use League\HTMLToMarkdown\Configuration;
+use League\HTMLToMarkdown\ConfigurationAwareInterface;
 use League\HTMLToMarkdown\ElementInterface;
 
-class CommentConverter implements ConverterInterface
+class CommentConverter implements ConverterInterface, ConfigurationAwareInterface
 {
+    /**
+     * @var Configuration
+     */
+    protected $config;
+
+    /**
+     * @param Configuration $config
+     */
+    public function setConfig(Configuration $config)
+    {
+        $this->config = $config;
+    }
+
     /**
      * @param ElementInterface $element
      *
@@ -13,6 +28,9 @@ class CommentConverter implements ConverterInterface
      */
     public function convert(ElementInterface $element)
     {
+        if ($this->shouldPreserve($element)) {
+            return '<!--' . $element->getValue() . '-->';
+        }
         return '';
     }
 
@@ -22,5 +40,23 @@ class CommentConverter implements ConverterInterface
     public function getSupportedTags()
     {
         return array('#comment');
+    }
+
+    /**
+     * @param ElementInterface $element
+     *
+     * @return bool
+     */
+    private function shouldPreserve(ElementInterface $element)
+    {
+        $preserve = $this->config->getOption('preserve_comments');
+        if ($preserve === true) {
+            return true;
+        }
+        if (is_array($preserve)) {
+            $value = trim($element->getValue());
+            return in_array($value, $preserve);
+        }
+        return false;
     }
 }

--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -40,6 +40,7 @@ class HtmlConverter implements HtmlConverterInterface
                 'remove_nodes' => '', // space-separated list of dom nodes that should be removed. example: 'meta style script'
                 'hard_break' => false, // Set to true to turn <br> into `\n` instead of `  \n`
                 'list_item_style' => '-', // Set the default character for each <li> in a <ul>. Can be '-', '*', or '+'
+                'preserve_comments' => false, // Set to true to preserve comments, or set to an array of strings to preserve specific comments
             );
 
             $this->environment = Environment::createDefaultEnvironment($defaults);
@@ -229,13 +230,13 @@ class HtmlConverter implements HtmlConverterInterface
 
         return trim($markdown, "\n\r\0\x0B");
     }
-    
+
     /**
      * Pass a series of key-value pairs in an array; these will be passed
      * through the config and set.
      * The advantage of this is that it can allow for static use (IE in Laravel).
      * An example being:
-     * 
+     *
      * HtmlConverter::setOptions(['strip_tags' => true])->convert('<h1>test</h1>');
      */
     public function setOptions(array $options)

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -237,6 +237,13 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown('<p>Test</p><!-- Test comment -->', 'Test', array('strip_tags' => true));
     }
 
+    public function test_preserve_comments()
+    {
+        $this->html_gives_markdown('<p>Test</p><!-- Test comment -->', "Test\n\n<!-- Test comment -->", array('preserve_comments' => true));
+        $this->html_gives_markdown('<p>Test</p><!-- more -->', "Test\n\n<!-- more -->", array('preserve_comments' => array('more')));
+        $this->html_gives_markdown('<p>Test</p><!-- Test comment --><!-- more -->', "Test\n\n<!-- more -->", array('preserve_comments' => array('more')));
+    }
+
     public function test_preserve_whitespace()
     {
         $this->html_gives_markdown('<a href="google.com">google.com</a> <code>test</code>', '[google.com](google.com) `test`');


### PR DESCRIPTION
This PR adds a new option to preserve comments. The current behavior is the default, i.e. strip all comments off.

As suggested by @Rarst on #177 the available options for `preserve_comments` are:

* `false` preserve no comment (**default**)
* `true` preserve all comments
* `string[]` preserve specific comments, e.g. `array( 'more' )`.

The option may be passed to the converter constructor, this way:

```
$markdown = new HtmlConverter(array(
    'preserve_comments' => true,
));
```