### PR TITLE
Fix lists containing multiple paragraphs

### DIFF
--- a/src/Converter/ListItemConverter.php
+++ b/src/Converter/ListItemConverter.php
@@ -39,7 +39,7 @@ class ListItemConverter implements ConverterInterface, ConfigurationAwareInterfa
         // Add spaces to start for nested list items
         $level = $element->getListItemLevel($element);
 
-        $prefixForParagraph = str_repeat('  ', $level + 1);
+        $prefixForParagraph = str_repeat("\t", $level + 1);
         $value = trim(implode("\n" . $prefixForParagraph, explode("\n", trim($element->getValue()))));
 
         // If list item is the first in a nested list, add a newline before it


### PR DESCRIPTION
Currently two spaces are used to indent multiple paragraphs inside a
list item. However, this doesn't seem to work correctly.

Using a tab character in place *does* work, at least in my
configurations. (i.e. Using it in combination with [Hugo](https://gohugo.io/), which in turn
uses [Blackfriday](https://github.com/russross/blackfriday))