### PR TITLE
Make autolinking configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,21 @@ $converter->getConfig()->setOption('hard_break', false); // default
 $markdown = $converter->convert($html); // $markdown now contains "test  \nline break"
 ```
 
+### Autolinking options
+
+By default, `a` tags are converted to the easiest possible link syntax, i.e. if no text or title is available, then the `<url>` syntax will be used rather than the full `[url](url)` syntax. Set `use_autolinks` to `false` to change this behavior to always use the full link syntax.
+
+```php
+$converter = new HtmlConverter();
+$html = '<p><a href="https://thephpleague.com">https://thephpleague.com</a></p>';
+
+$converter->getConfig()->setOption('use_autolinks', true);
+$markdown = $converter->convert($html); // $markdown now contains "<https://thephpleague.com>"
+
+$converter->getConfig()->setOption('use_autolinks', false); // default
+$markdown = $converter->convert($html); // $markdown now contains "[https://google.com](https://google.com)"
+```
+
 ### Passing custom Environment object
 
 You can pass current `Environment` object to customize i.e. which converters should be used.

--- a/src/Converter/LinkConverter.php
+++ b/src/Converter/LinkConverter.php
@@ -2,10 +2,24 @@
 
 namespace League\HTMLToMarkdown\Converter;
 
+use League\HTMLToMarkdown\Configuration;
+use League\HTMLToMarkdown\ConfigurationAwareInterface;
 use League\HTMLToMarkdown\ElementInterface;
 
-class LinkConverter implements ConverterInterface
+class LinkConverter implements ConverterInterface, ConfigurationAwareInterface
 {
+    /**
+     * @var Configuration
+     */
+    protected $config;
+
+    /**
+     * @param Configuration $config
+     */
+    public function setConfig(Configuration $config) {
+        $this->config = $config;
+    }
+
     /**
      * @param ElementInterface $element
      *
@@ -52,7 +66,8 @@ class LinkConverter implements ConverterInterface
      */
     private function isValidAutolink($href)
     {
-        return preg_match('/^[A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\x00-\x20]*/i', $href) === 1;
+        $useAutolinks = $this->config->getOption('use_autolinks');
+        return $useAutolinks && (preg_match('/^[A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\x00-\x20]*/i', $href) === 1);
     }
 
     /**

--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -41,6 +41,7 @@ class HtmlConverter implements HtmlConverterInterface
                 'hard_break' => false, // Set to true to turn <br> into `\n` instead of `  \n`
                 'list_item_style' => '-', // Set the default character for each <li> in a <ul>. Can be '-', '*', or '+'
                 'preserve_comments' => false, // Set to true to preserve comments, or set to an array of strings to preserve specific comments
+                'use_autolinks' => true, // Set to true to use simple link syntax if possible. Will always use []() if set to false
             );
 
             $this->environment = Environment::createDefaultEnvironment($defaults);

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -133,6 +133,16 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown('<a href="ftp://files.example.com">ftp://files.example.com</a>', '<ftp://files.example.com>');
         $this->html_gives_markdown('<a href="mailto:test@example.com">test@example.com</a>', '<test@example.com>');
         $this->html_gives_markdown('<a href="mailto:test+foo@example.bar-baz.com">test+foo@example.bar-baz.com</a>', '<test+foo@example.bar-baz.com>');
+
+        // Autolinking can be toggled off
+        $markdown = new HtmlConverter();
+        $markdown->getConfig()->setOption('use_autolinks', false);
+        $result = $markdown('<a href="https://www.google.com">https://www.google.com</a>');
+        $this->assertEquals('[https://www.google.com](https://www.google.com)', $result);
+        $result = $markdown('<a href="https://www.google.com">Google</a>');
+        $this->assertEquals('[Google](https://www.google.com)', $result);
+        $result = $markdown('<a href="google.com">google.com</a>');
+        $this->assertEquals('[google.com](google.com)', $result);
     }
 
     public function test_horizontal_rule()

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -135,14 +135,9 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown('<a href="mailto:test+foo@example.bar-baz.com">test+foo@example.bar-baz.com</a>', '<test+foo@example.bar-baz.com>');
 
         // Autolinking can be toggled off
-        $markdown = new HtmlConverter();
-        $markdown->getConfig()->setOption('use_autolinks', false);
-        $result = $markdown('<a href="https://www.google.com">https://www.google.com</a>');
-        $this->assertEquals('[https://www.google.com](https://www.google.com)', $result);
-        $result = $markdown('<a href="https://www.google.com">Google</a>');
-        $this->assertEquals('[Google](https://www.google.com)', $result);
-        $result = $markdown('<a href="google.com">google.com</a>');
-        $this->assertEquals('[google.com](google.com)', $result);
+        $this->html_gives_markdown('<a href="https://www.google.com">https://www.google.com</a>', '[https://www.google.com](https://www.google.com)', array('use_autolinks' => false));
+        $this->html_gives_markdown('<a href="https://www.google.com">Google</a>', '[Google](https://www.google.com)', array('use_autolinks' => false));
+        $this->html_gives_markdown('<a href="google.com">google.com</a>', '[google.com](google.com)', array('use_autolinks' => false));
     }
 
     public function test_horizontal_rule()


### PR DESCRIPTION
Feature request thephpleague/html-to-markdown#187
* Configuration `use_autolinks` added
* When set to `false`, the short link syntax `<url>` will not be used