### PR TITLE
Added stripping of placeholder links

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ $html = '<span>Turnips!</span><!-- Monkeys! --><!-- Eggs! -->';
 $markdown = $converter->convert($html); // $markdown now contains "Turnips!<!-- Eggs! -->"
 ```
 
+By default, placeholder links are preserved. To strip the placeholder links, use the `strip_placeholder_links` option, like this:
+
+```php
+$converter = new HtmlConverter(array('strip_placeholder_links' => true));
+
+$html = '<a>Github</a>';
+$markdown = $converter->convert($html); // $markdown now contains "Github"
+```
+
 ### Style options
 
 By default bold tags are converted using the asterisk syntax, and italic tags are converted using the underlined syntax. Change these by using the `bold_style` and `italic_style` options.

--- a/src/Converter/LinkConverter.php
+++ b/src/Converter/LinkConverter.php
@@ -45,7 +45,11 @@ class LinkConverter implements ConverterInterface, ConfigurationAwareInterface
         }
 
         if (!$href) {
-            $markdown = html_entity_decode($element->getChildrenAsString());
+            if ($this->shouldStrip()) {
+                $markdown = $text;
+            } else {
+                $markdown = html_entity_decode($element->getChildrenAsString());
+            }
         }
 
         return $markdown;
@@ -79,5 +83,13 @@ class LinkConverter implements ConverterInterface, ConfigurationAwareInterface
     {
         // Email validation is messy business, but this should cover most cases
         return filter_var($email, FILTER_VALIDATE_EMAIL);
+    }
+
+    /**
+     * @return bool
+     */
+    private function shouldStrip()
+    {
+        return $this->config->getOption('strip_placeholder_links');
     }
 }

--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -35,6 +35,7 @@ class HtmlConverter implements HtmlConverterInterface
                 'header_style' => 'setext', // Set to 'atx' to output H1 and H2 headers as # Header1 and ## Header2
                 'suppress_errors' => true, // Set to false to show warnings when loading malformed HTML
                 'strip_tags' => false, // Set to true to strip tags that don't have markdown equivalents. N.B. Strips tags, not their content. Useful to clean MS Word HTML output.
+                'strip_placeholder_links' => false, // Set to true to remove <a> that doesn't have href.
                 'bold_style' => '**', // DEPRECATED: Set to '__' if you prefer the underlined style
                 'italic_style' => '*', // DEPRECATED: Set to '_' if you prefer the underlined style
                 'remove_nodes' => '', // space-separated list of dom nodes that should be removed. example: 'meta style script'

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -126,6 +126,12 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown('<a href="#nerd" title="Title">Test</a>', '[Test](#nerd "Title")');
         $this->html_gives_markdown('<a href="#nerd">Test</a>', '[Test](#nerd)');
 
+        // Strip placeholder links
+        $this->html_gives_markdown('<a>Test</a>', 'Test', array('strip_placeholder_links' => true));
+        $this->html_gives_markdown('<a href="">Test</a>', 'Test', array('strip_placeholder_links' => true));
+        $this->html_gives_markdown('<a href="#nerd" title="Title">Test</a>', '[Test](#nerd "Title")', array('strip_placeholder_links' => true));
+        $this->html_gives_markdown('<a href="#nerd">Test</a>', '[Test](#nerd)', array('strip_placeholder_links' => true));
+
         // Autolinking
         $this->html_gives_markdown('<a href="test">test</a>', '[test](test)');
         $this->html_gives_markdown('<a href="google.com">google.com</a>', '[google.com](google.com)');


### PR DESCRIPTION
I wanted to remove `a` tags that don't have `href` but retain the other `a` tags.

To retain the default behavior, I added `strip_placeholder_links` which defaults to `false`.