### PR TITLE
Fix consecutive emphasis producing incorrect markdown

### DIFF
--- a/src/Element.php
+++ b/src/Element.php
@@ -15,7 +15,7 @@ class Element implements ElementInterface
     private $nextCached;
 
     /**
-     * @var ElementInterface|null
+     * @var DOMNode|null
      */
     private $previousSiblingCached;
 

--- a/src/Element.php
+++ b/src/Element.php
@@ -14,9 +14,15 @@ class Element implements ElementInterface
      */
     private $nextCached;
 
+    /**
+     * @var ElementInterface|null
+     */
+    private $previousSiblingCached;
+
     public function __construct(\DOMNode $node)
     {
         $this->node = $node;
+        $this->previousSiblingCached = $this->node->previousSibling;
     }
 
     /**
@@ -84,6 +90,22 @@ class Element implements ElementInterface
     public function getParent()
     {
         return new static($this->node->parentNode) ?: null;
+    }
+
+    /**
+     * @return ElementInterface|null
+     */
+    public function getNextSibling()
+    {
+        return $this->node->nextSibling !== null ? new static($this->node->nextSibling) : null;
+    }
+
+    /**
+     * @return ElementInterface|null
+     */
+    public function getPreviousSibling()
+    {
+        return $this->previousSiblingCached !== null ? new static($this->previousSiblingCached) : null;
     }
 
     /**

--- a/src/ElementInterface.php
+++ b/src/ElementInterface.php
@@ -35,6 +35,16 @@ interface ElementInterface
     public function getParent();
 
     /**
+     * @return ElementInterface|null
+     */
+    public function getNextSibling();
+
+    /**
+     * @return ElementInterface|null
+     */
+    public function getPreviousSibling();
+
+    /**
      * @param string|string[] $tagNames
      *
      * @return bool

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -95,6 +95,19 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->html_gives_markdown("Emphasis preserves<em><br/></em>HTML breaks", "Emphasis preserves  \nHTML breaks");
     }
 
+    public function test_consecutive_spans()
+    {
+        $this->html_gives_markdown('<em>Foo</em><em>Bar</em>', '*FooBar*');
+        $this->html_gives_markdown('<i>Foo</i><i>Bar</i>', '*FooBar*');
+        $this->html_gives_markdown('<em>Foo</em><i>Bar</i><em>Foo</em>', '*FooBarFoo*');
+        $this->html_gives_markdown('<strong>Foo</strong><strong>Bar</strong>', '**FooBar**');
+        $this->html_gives_markdown('<b>Foo</b><b>Bar</b>', '**FooBar**');
+        $this->html_gives_markdown('<strong>Foo</strong><b>Bar</b><strong>Foo</strong>', '**FooBarFoo**');
+        $this->html_gives_markdown('<em>Foo</em> <em>Bar</em>', '*Foo* *Bar*');
+        $this->html_gives_markdown('<strong>Foo</strong> <strong>Bar</strong>', '**Foo** **Bar**');
+        $this->html_gives_markdown('<strong>Foo</strong><b>Bar</b><em>Foo</em>', '**FooBar***Foo*');
+    }
+
     public function test_nesting()
     {
         $this->html_gives_markdown('<span><span>Test</span></span>', '<span><span>Test</span></span>');


### PR DESCRIPTION
This is a fix for issue #199.

By checking the type of the immediate previous or following sibling node we can avoid emitting the incorrect style. To access the previous sibling we need to cache it on Element creation because it will already be replaced by markdown when the current node is being converted.