### PR TITLE
Add support for tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,21 @@ $html = '<h3>Header</h3>
 $markdown = $converter->convert($html); // $markdown now contains "### Header" and "<img src="" />"
 ```
 
+### Table support
+
+Support for Markdown tables is not enabled by default because it is not part of the original Markdown syntax. To use tables add the converter explicitly:
+
+```php
+use League\HTMLToMarkdown\HtmlConverter;
+use League\HTMLToMarkdown\Converter\TableConverter;
+
+$converter = new HtmlConverter();
+$converter->getEnvironment()->addConverter(new TableConverter());
+
+$html = "<table><tr><th>A</th></tr><tr><td>a</td></tr></table>";
+$markdown = $converter->convert($html);
+```
+
 ### Limitations
 
 - Markdown Extra, MultiMarkdown and other variants aren't supported – just Markdown.

--- a/src/Converter/ConverterInterface.php
+++ b/src/Converter/ConverterInterface.php
@@ -18,3 +18,13 @@ interface ConverterInterface
      */
     public function getSupportedTags();
 }
+
+interface PreConverterInterface
+{
+    /**
+     * @param ElementInterface $element
+     *
+     * @return void
+     */
+    public function preConvert(ElementInterface $element);
+}

--- a/src/Converter/DefaultConverter.php
+++ b/src/Converter/DefaultConverter.php
@@ -39,6 +39,7 @@ class DefaultConverter implements ConverterInterface, ConfigurationAwareInterfac
 
         $markdown = html_entity_decode($element->getChildrenAsString());
 
+        // Tables are only handled here if TableConverter is not used
         if ($element->getTagName() === 'table') {
             $markdown .= "\n\n";
         }

--- a/src/Converter/TableConverter.php
+++ b/src/Converter/TableConverter.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace League\HTMLToMarkdown\Converter;
+
+use League\HTMLToMarkdown\Configuration;
+use League\HTMLToMarkdown\ConfigurationAwareInterface;
+use League\HTMLToMarkdown\ElementInterface;
+
+class TableConverter implements ConverterInterface, PreConverterInterface, ConfigurationAwareInterface
+{
+    /**
+     * @var Configuration
+     */
+    protected $config;
+
+    /**
+     * @param Configuration $config
+     */
+    public function setConfig(Configuration $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @var array
+     */
+    private static $alignments = array(
+        'left' => ':--',
+        'right' => '--:',
+        'center' => ':-:',
+    );
+
+    /**
+     * @var array
+     */
+    private $columnAlignments = array();
+
+    /**
+     * @var str
+     */
+    private $caption = null;
+
+    /**
+     * @param ElementInterface $element
+     *
+     * @return void
+     */
+    public function preConvert(ElementInterface $element)
+    {
+        $tag = $element->getTagName();
+        // Only table cells and caption are allowed to contain content.
+        // Remove all text between other table elements.
+        if ($tag !== 'th' and $tag !== 'td' and $tag !== 'caption') {
+            foreach ($element->getChildren() as $child) {
+                if ($child->isText()) {
+                    $child->setFinalMarkdown('');
+                }
+            }
+        }
+    }
+
+    /**
+     * @param ElementInterface $element
+     *
+     * @return string
+     */
+    public function convert(ElementInterface $element)
+    {
+        $value = $element->getValue();
+
+        switch ($element->getTagName()) {
+            case 'table':
+                $this->columnAlignments = array();
+                if ($this->caption) {
+                    $side = $this->config->getOption('table_caption_side');
+                    if ($side === 'top') {
+                        $value = $this->caption . "\n" . $value;
+                    } else if ($side === 'bottom') {
+                        $value .= $this->caption;
+                    }
+                    $this->caption = null;
+                }
+                return $value . "\n";
+            case 'caption':
+                $this->caption = trim($value);
+                return '';
+            case 'tr':
+                $value .= "|\n";
+                if ($this->columnAlignments !== null) {
+                    $value .= "|" . implode("|", $this->columnAlignments) . "|\n";
+                    $this->columnAlignments = null;
+                }
+                return $value;
+            case 'th':
+            case 'td':
+                if ($this->columnAlignments !== null) {
+                    $align = $element->getAttribute('align');
+                    $this->columnAlignments[] = isset(self::$alignments[$align]) ? self::$alignments[$align] : '---';
+                }
+                $value = str_replace("\n", ' ', $value);
+                $value = str_replace('|', $this->config->getOption('table_pipe_escape'), $value);
+                return '| ' . trim($value) . ' ';
+            case 'thead':
+            case 'tbody':
+            case 'tfoot':
+            case 'colgroup':
+            case 'col':
+                return $value;
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSupportedTags()
+    {
+        return array('table', 'tr', 'th', 'td', 'thead', 'tbody', 'tfoot', 'colgroup', 'col', 'caption');
+    }
+}


### PR DESCRIPTION
This adds support for Markdown tables and resolves issue #201. 

Because tables are extended Markdown the converter is not enabled by default and needs to be added by the user explicitly.

Implementing more complex conversions like tables is not easy to do in purely bottom-up fashion. To make this easier this PR also adds a `PreConverterInterface` which converters can implement to be called before children are traversed. This provides and opportunity to inspect and modify the DOM while children are still unmodified.