### PR TITLE
#212: Find and move any misplaced comment nodes

### DIFF
--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -327,14 +327,21 @@ EOT;
     public function testStripComments(): void
     {
         $this->assertHtmlGivesMarkdown('<p>Test</p><!-- Test comment -->', 'Test');
+        $this->assertHtmlGivesMarkdown('<!-- Test comment --><p>Test</p>', 'Test');
         $this->assertHtmlGivesMarkdown('<p>Test</p><!-- Test comment -->', 'Test', ['strip_tags' => true]);
+        $this->assertHtmlGivesMarkdown('<!-- Test comment --><p>Test</p>', 'Test', ['strip_tags' => true]);
     }
 
     public function testPreserveComments(): void
     {
-        $this->assertHtmlGivesMarkdown('<p>Test</p><!-- Test comment -->', "Test\n\n<!-- Test comment -->", ['preserve_comments' => true]);
         $this->assertHtmlGivesMarkdown('<p>Test</p><!-- more -->', "Test\n\n<!-- more -->", ['preserve_comments' => ['more']]);
         $this->assertHtmlGivesMarkdown('<p>Test</p><!-- Test comment --><!-- more -->', "Test\n\n<!-- more -->", ['preserve_comments' => ['more']]);
+        $this->assertHtmlGivesMarkdown('<!-- Test comment --><p>Test</p><!-- Test comment -->', "<!-- Test comment -->Test\n\n<!-- Test comment -->", ['preserve_comments' => true]);
+    }
+
+    public function testPreserveCommentOrder(): void
+    {
+        $this->assertHtmlGivesMarkdown('<!-- 1 --><!-- 2 --><p>Test</p><!-- 3 -->', "<!-- 1 --><!-- 2 -->Test\n\n<!-- 3 -->", ['preserve_comments' => true]);
     }
 
     public function testPreserveWhitespace(): void


### PR DESCRIPTION
This is a fix for https://github.com/thephpleague/html-to-markdown/issues/212: if you pass HTML that begins with a comment (like `<!-- uh oh --><p>hi</p>`) to `HtmlConverter->convert`, the resulting markdown looks like this: `<!-- uh oh --><html><body>hi\n`.

This is because `DOMDocument->loadHTML` actually puts that first comment at the root of the document, *outside* the `html` and `body` tags. The `sanitize` method only removes `html` and `body` tags [if they're at position 0 of the markdown string](https://github.com/bigsweater/html-to-markdown/blob/03fad17ef570ae3af62bdebb7a31e59fda7226d7/src/HtmlConverter.php#L230-L232) -- but with the comment at the root of the document, the position of the tags will always be > 0, so they never get removed (and that first comment is never removed, either).

So this adds a step to the `createDOMDocument` method: it finds any comments at the root of the `DOMDocument` and prepends them to the `<body>` tag.

Evidently [DOMDocument has always behaved this way](https://3v4l.org/7bC33), so maybe this isn't the correct fix?