### PR TITLE
Trim regular spaces from link text

### DIFF
--- a/src/Converter/LinkConverter.php
+++ b/src/Converter/LinkConverter.php
@@ -22,7 +22,7 @@ class LinkConverter implements ConverterInterface, ConfigurationAwareInterface
     {
         $href  = $element->getAttribute('href');
         $title = $element->getAttribute('title');
-        $text  = \trim($element->getValue(), "\t\n\r\0\x0B");
+        $text  = \trim($element->getValue(), "\t\n\r\0\x0B ");
 
         if ($title !== '') {
             $markdown = '[' . $text . '](' . $href . ' "' . $title . '")';

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -142,7 +142,7 @@ class HtmlConverterTest extends TestCase
         $this->assertHtmlGivesMarkdown('<a href="http://modernnerd.net" title="Title">Modern Nerd</a>', '[Modern Nerd](http://modernnerd.net "Title")');
         $this->assertHtmlGivesMarkdown('<a href="http://modernnerd.net" title="Title">Modern Nerd</a> <a href="http://modernnerd.net" title="Title">Modern Nerd</a>', '[Modern Nerd](http://modernnerd.net "Title") [Modern Nerd](http://modernnerd.net "Title")');
         $this->assertHtmlGivesMarkdown('<a href="http://modernnerd.net"><h3>Modern Nerd</h3></a>', '[### Modern Nerd](http://modernnerd.net)');
-        $this->assertHtmlGivesMarkdown('The <a href="http://modernnerd.net">Modern Nerd </a>(MN)', 'The [Modern Nerd ](http://modernnerd.net)(MN)');
+        $this->assertHtmlGivesMarkdown('The <a href="http://modernnerd.net">Modern Nerd </a>(MN)', 'The [Modern Nerd](http://modernnerd.net)(MN)');
         $this->assertHtmlGivesMarkdown('<a href="http://modernnerd.net/" title="Title"><img src="/path/img.jpg" alt="alt text" title="Title"/></a>', '[![alt text](/path/img.jpg "Title")](http://modernnerd.net/ "Title")');
         $this->assertHtmlGivesMarkdown('<a href="http://modernnerd.net/" title="Title"><img src="/path/img.jpg" alt="alt text" title="Title"/> Test</a>', '[![alt text](/path/img.jpg "Title") Test](http://modernnerd.net/ "Title")');
 


### PR DESCRIPTION
I'm not sure if omitting regular spaces was intentional, but we were very surprised by this behaviour while switching from [soundasleep/html2text](https://packagist.org/packages/soundasleep/html2text) to this library.

In particular, here is some output in our project, before and after this PR.

**Before:**

```markdown
[ https://www.example.com/r/pro/7 ](https://www.example.com/r/pro/7)
[ 09 80 80 00 00 ](tel:+33980800000)
```

**After:**

```markdown
<https://www.example.com/r/pro/7>
[09 80 80 00 00](tel:+33980800000)
```