### PR TITLE
#226: Escape setext heading underlines.

### DIFF
--- a/src/Converter/ParagraphConverter.php
+++ b/src/Converter/ParagraphConverter.php
@@ -56,6 +56,7 @@ class ParagraphConverter implements ConverterInterface
             '~~~',
             '---',
             '- - -',
+            '=',
         ];
 
         foreach ($escapable as $i) {

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -401,6 +401,7 @@ EOT;
         $this->assertHtmlGivesMarkdown($html, $markdown);
         $this->assertHtmlGivesMarkdown('<p>&gt; &gt; Look at me! &lt; &lt;</p>', '&gt; &gt; Look at me! &lt; &lt;');
         $this->assertHtmlGivesMarkdown('<p>&gt; &gt; <b>Look</b> at me! &lt; &lt;<br />&gt; Just look at me!</p>', "&gt; &gt; **Look** at me! &lt; &lt;  \n&gt; Just look at me!");
+        $this->assertHtmlGivesMarkdown('<p>Foo<br>=<br>Bar</p>', "Foo  \n\\=  \nBar");
         $this->assertHtmlGivesMarkdown('<p>Foo<br>--<br>Bar<br>Foo--</p>', "Foo  \n\\--  \nBar  \nFoo--");
         $this->assertHtmlGivesMarkdown('<ul><li>Foo<br>- Bar</li></ul>', "- Foo  \n    \\- Bar");
         $this->assertHtmlGivesMarkdown('Foo<br />* Bar', "Foo  \n\\* Bar");


### PR DESCRIPTION
Fixes #226 