### PR TITLE
Fix sanitizer function for libxml2 >= 2.14 and HTML5

### DIFF
--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -233,7 +233,7 @@ class HtmlConverter implements HtmlConverterInterface
          * Removing unwanted tags. Tags should be added to the array in the order they are expected.
          * XML, html and body opening tags should be in that order. Same case with closing tags
          */
-        $unwanted = ['<?xml encoding="UTF-8">', '<html>', '</html>', '<body>', '</body>', '<head>', '</head>', '&#xD;'];
+        $unwanted = ['<?xml encoding="UTF-8">', '<!--?xml encoding="UTF-8"-->', '<html>', '</html>', '<body>', '<!--?xml encoding="UTF-8"-->', '</body>', '<head>', '</head>', '&#xD;'];
 
         foreach ($unwanted as $tag) {
             if (\strpos($tag, '/') === false) {


### PR DESCRIPTION
This is adapting the sanitize function to remove commented XML tags from the resulting markdown.
Fixes: #263