### PR TITLE
Restore libxml error state after conversion

### DIFF
--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -110,21 +110,25 @@ class HtmlConverter implements HtmlConverterInterface
 
     private function createDOMDocument(string $html): \DOMDocument
     {
-        $document = new \DOMDocument();
+        $document                 = new \DOMDocument();
+        $previousLibxmlErrorState = null;
 
         if ($this->getConfig()->getOption('suppress_errors')) {
             // Suppress conversion errors (from http://bit.ly/pCCRSX)
-            \libxml_use_internal_errors(true);
+            $previousLibxmlErrorState = \libxml_use_internal_errors(true);
         }
 
-        // Hack to load utf-8 HTML (from http://bit.ly/pVDyCt)
-        $document->loadHTML('<?xml encoding="UTF-8">' . $html);
-        $document->encoding = 'UTF-8';
+        try {
+            // Hack to load utf-8 HTML (from http://bit.ly/pVDyCt)
+            $document->loadHTML('<?xml encoding="UTF-8">' . $html);
+            $document->encoding = 'UTF-8';
 
-        $this->replaceMisplacedComments($document);
-
-        if ($this->getConfig()->getOption('suppress_errors')) {
-            \libxml_clear_errors();
+            $this->replaceMisplacedComments($document);
+        } finally {
+            if ($this->getConfig()->getOption('suppress_errors')) {
+                \libxml_clear_errors();
+                \libxml_use_internal_errors($previousLibxmlErrorState);
+            }
         }
 
         return $document;

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -316,6 +316,34 @@ EOT;
         $this->assertHtmlGivesMarkdown('<strong><em>Strong italic</strong> Regular text', '***Strong italic*** Regular text'); // Missing closing </em>
     }
 
+    public function testLibxmlInternalErrorsIsRestoredAfterConvert(): void
+    {
+        $previousState = \libxml_use_internal_errors(false);
+
+        try {
+            $converter = new HtmlConverter();
+            $converter->convert('<p>Hello</p>');
+
+            $this->assertFalse(\libxml_use_internal_errors());
+        } finally {
+            \libxml_use_internal_errors($previousState);
+        }
+    }
+
+    public function testLibxmlInternalErrorsIsUnchangedWhenSuppressErrorsDisabled(): void
+    {
+        $previousState = \libxml_use_internal_errors(true);
+
+        try {
+            $converter = new HtmlConverter(['suppress_errors' => false]);
+            $converter->convert('<p>Hello</p>');
+
+            $this->assertTrue(\libxml_use_internal_errors());
+        } finally {
+            \libxml_use_internal_errors($previousState);
+        }
+    }
+
     public function testHtml5TagsArePreserved(): void
     {
         $this->assertHtmlGivesMarkdown('<article>Some stuff</article>', '<article>Some stuff</article>');


### PR DESCRIPTION
## Summary
- Restore previous libxml internal error state after HTML conversion
- Add tests to ensure state is restored and unchanged when suppression is disabled

## Testing
- ./vendor/bin/phpunit (PHP 7.4.33)
- ./vendor/bin/phpunit (PHP 8.0.30)
- PHP >= 8.1: local failures in existing tests (XML header output; unrelated to this change)

Fixes #268 