### PR TITLE
Fix unbalanced markdown when an emphasis span is next to a whitespace-only one

### DIFF
--- a/src/Converter/EmphasisConverter.php
+++ b/src/Converter/EmphasisConverter.php
@@ -63,16 +63,18 @@ class EmphasisConverter implements ConverterInterface, ConfigurationAwareInterfa
     }
 
     /**
-     * A same-type sibling only emits emphasis markers when it has non-whitespace
-     * content; a whitespace-only sibling returns its bare value (see the early
-     * return above) and emits none. Suppressing our marker is only correct in
-     * the former case, otherwise the output is left unbalanced (issue #252).
+     * A same-type sibling only emits emphasis markers when its trimmed content is
+     * truthy; a sibling whose trimmed value is falsy (whitespace-only, or "0")
+     * returns its bare value (see the early return in convert()) and emits none.
+     * Suppressing our marker is only correct in the former case, otherwise the
+     * output is left unbalanced (issue #252). The truthiness check mirrors
+     * convert()'s `! \trim($value)` guard so the two stay consistent.
      */
     private function isMergeableSibling(?ElementInterface $sibling, string $tag): bool
     {
         return $sibling !== null
             && $this->getNormTag($sibling) === $tag
-            && \trim($sibling->getValue()) !== '';
+            && (bool) \trim($sibling->getValue());
     }
 
     /**

--- a/src/Converter/EmphasisConverter.php
+++ b/src/Converter/EmphasisConverter.php
@@ -56,10 +56,23 @@ class EmphasisConverter implements ConverterInterface, ConfigurationAwareInterfa
          * the start or end $style, respectively. This prevents <em>foo</em><em>bar</em> from
          * being converted to *foo**bar* which is incorrect. We want *foobar* instead.
          */
-        $preStyle  = $this->getNormTag($element->getPreviousSibling()) === $tag ? '' : $style;
-        $postStyle = $this->getNormTag($element->getNextSibling()) === $tag ? '' : $style;
+        $preStyle  = $this->isMergeableSibling($element->getPreviousSibling(), $tag) ? '' : $style;
+        $postStyle = $this->isMergeableSibling($element->getNextSibling(), $tag) ? '' : $style;
 
         return $prefix . $preStyle . \trim($value) . $postStyle . $suffix;
+    }
+
+    /**
+     * A same-type sibling only emits emphasis markers when it has non-whitespace
+     * content; a whitespace-only sibling returns its bare value (see the early
+     * return above) and emits none. Suppressing our marker is only correct in
+     * the former case, otherwise the output is left unbalanced (issue #252).
+     */
+    private function isMergeableSibling(?ElementInterface $sibling, string $tag): bool
+    {
+        return $sibling !== null
+            && $this->getNormTag($sibling) === $tag
+            && \trim($sibling->getValue()) !== '';
     }
 
     /**

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -123,6 +123,8 @@ class HtmlConverterTest extends TestCase
         // adjacent span must keep its own instead of merging (issue #252).
         $this->assertHtmlGivesMarkdown('<strong> </strong><strong>hello</strong>', ' **hello**');
         $this->assertHtmlGivesMarkdown('<em> </em><em>hello</em>', ' *hello*');
+        $this->assertHtmlGivesMarkdown('<strong>hello</strong><strong> </strong>', '**hello** ');
+        $this->assertHtmlGivesMarkdown('<em>hello</em><em> </em>', '*hello* ');
     }
 
     public function testNesting(): void

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -119,6 +119,10 @@ class HtmlConverterTest extends TestCase
         $this->assertHtmlGivesMarkdown('<em>Foo</em> <em>Bar</em>', '*Foo* *Bar*');
         $this->assertHtmlGivesMarkdown('<strong>Foo</strong> <strong>Bar</strong>', '**Foo** **Bar**');
         $this->assertHtmlGivesMarkdown('<strong>Foo</strong><b>Bar</b><em>Foo</em>', '**FooBar***Foo*');
+        // A whitespace-only neighbour of the same type emits no markers, so the
+        // adjacent span must keep its own instead of merging (issue #252).
+        $this->assertHtmlGivesMarkdown('<strong> </strong><strong>hello</strong>', ' **hello**');
+        $this->assertHtmlGivesMarkdown('<em> </em><em>hello</em>', ' *hello*');
     }
 
     public function testNesting(): void

--- a/tests/HtmlConverterTest.php
+++ b/tests/HtmlConverterTest.php
@@ -125,6 +125,10 @@ class HtmlConverterTest extends TestCase
         $this->assertHtmlGivesMarkdown('<em> </em><em>hello</em>', ' *hello*');
         $this->assertHtmlGivesMarkdown('<strong>hello</strong><strong> </strong>', '**hello** ');
         $this->assertHtmlGivesMarkdown('<em>hello</em><em> </em>', '*hello* ');
+        // A same-type neighbour whose trimmed content is falsy (e.g. "0") also
+        // emits no markers, so the adjacent span must keep its own (issue #252).
+        $this->assertHtmlGivesMarkdown('<em>0</em><em>hello</em>', '0*hello*');
+        $this->assertHtmlGivesMarkdown('<em>hello</em><em>0</em>', '*hello*0');
     }
 
     public function testNesting(): void


### PR DESCRIPTION
Fixes #252.

`EmphasisConverter` has a "merge adjacent same-type emphasis" optimization (added in #202) so that `<em>foo</em><em>bar</em>` becomes `*foobar*` rather than `*foo**bar*`. It suppresses a span's opening marker when the previous sibling is the same emphasis type (and its closing marker when the next sibling is), assuming that neighbour emitted markers of its own.

But a whitespace-only span short-circuits earlier (`if (! \trim($value)) { return $value; }`) and emits **no** markers. So when such a span is adjacent to a real one, the real span still drops its marker and the output is unbalanced:

```
<strong> </strong><strong>hello</strong>   =>   " hello**"   (missing opening **)
```

**Fix:** only merge with a same-type sibling that has non-whitespace content (i.e. one that actually emitted markers). Content-bearing merges (`<em>foo</em><em>bar</em>` -> `*foobar*`) are unchanged.

**Tests:** added whitespace-only-neighbour cases to `testConsecutiveSpans` (`<strong> </strong><strong>hello</strong>` -> ` **hello**`, plus the `<em>` variant). Verified red before the fix (`" hello**"`) and green after. `composer phpunit` (50 tests, 231 assertions), `phpstan`, and `psalm` all pass locally.

---

Disclosure: developed with the assistance of Claude Code (AI); reviewed and verified by me.
